### PR TITLE
Improved SCUMMVM detection using --recursive

### DIFF
--- a/src/data/compat/ScummVM.vala
+++ b/src/data/compat/ScummVM.vala
@@ -65,20 +65,13 @@ namespace GameHub.Data.Compat
 		public override bool can_run(Runnable runnable)
 		{
 			return installed && runnable is Game && runnable.install_dir != null
-				&& (scummvm_detect(runnable.install_dir) != "" 
-                                ||  scummvm_detect(runnable.install_dir.get_child("data")) != "" );
+				&& scummvm_detect(runnable.install_dir) != "";
 		}
 
 		public override async void run(Runnable runnable)
 		{
 			if(!can_run(runnable)) return;
-
-			var data_dir = runnable.install_dir.get_child("data");
-
                         var dir = scummvm_detect(runnable.install_dir); 
-                        if (dir == "")
-                            dir = scummvm_detect(data_dir);
-
 			yield Utils.run_thread({ executable.get_path(), "--auto-detect" }, dir);
 		}
 	}


### PR DESCRIPTION
This patch will improve the detection and use of SCUMMVM games using the `--recursive` flag for the detection. Once a game is detected in a sub-directory, GameHub parses the result and uses the sub-directory to play the game using the `--auto-detect` flag. Some games like World of Xeen need this to be properly played using SCUMMVM.