### PR TITLE
Override optimization cflags set by users or build systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ scripts/build.sh build_deb
 ```bash
 git clone https://github.com/tkashkin/GameHub.git
 cd GameHub
-meson build --prefix=/usr -Ddistro=generic --buildtype=debug
+CFLAGS="$CFLAGS -O0" meson build --prefix=/usr -Ddistro=generic --buildtype=debug
 cd build
 ninja
 sudo ninja install


### PR DESCRIPTION
This overrides optimization CFLAGS set in build system, and possibly user settings.

Hopefully this can avoid #99 / #103 / #112 / #162 at least a bit.

Perhaps @neuromancer could verify this works for him too? I originally used your tip to unset cflags completely, but I think this way is better as a general advice.