### PR TITLE
Use smaller actionbuttons if symbolic (#165)

### DIFF
--- a/src/ui/views/GameDetailsView/GameDetailsPage.vala
+++ b/src/ui/views/GameDetailsView/GameDetailsPage.vala
@@ -216,6 +216,11 @@ namespace GameHub.UI.Views.GameDetailsView
 			action_uninstall = add_action("edit-delete", null, (game is Sources.User.UserGame) ? _("Remove") : _("Uninstall"), uninstall_game);
 			action_properties = add_action("system-run", null, _("Game properties"), game_properties);
 
+			if (Settings.UI.get_instance().symbolic_icons) {
+				action_run_with_compat.icon = "platform-windows-symbolic";
+				action_run_with_compat.icon_overlay = null;
+			}
+
 			action_cancel.clicked.connect(() => {
 				if(download != null) download.cancel();
 			});
@@ -337,7 +342,8 @@ namespace GameHub.UI.Views.GameDetailsView
 					{
 						if(tool.id == game.compat_tool)
 						{
-							action_run_with_compat.icon_overlay = tool.icon;
+							var compat_icon_type = Settings.UI.get_instance().symbolic_icons ? "icon" : "icon_overlay";
+							action_run_with_compat.set_property(compat_icon_type, tool.icon);
 							break;
 						}
 					}

--- a/src/ui/widgets/ActionButton.vala
+++ b/src/ui/widgets/ActionButton.vala
@@ -36,14 +36,17 @@ namespace GameHub.UI.Widgets
 		{
 			get_style_context().add_class(Gtk.STYLE_CLASS_FLAT);
 
+			var ui_settings = GameHub.Settings.UI.get_instance();
+			var icon_size = ui_settings.symbolic_icons ? IconSize.LARGE_TOOLBAR : IconSize.DIALOG;
+			var button_size = int.max(icon_size, 32);
 			var box = new Box(Orientation.HORIZONTAL, 8);
 
 			var overlay = new Overlay();
 			overlay.valign = Align.START;
-			overlay.set_size_request(48, 48);
+			overlay.set_size_request(button_size, button_size);
 
-			var image = new Image.from_icon_name(icon, IconSize.DIALOG);
-			image.set_size_request(48, 48);
+			var image = new Image.from_icon_name(icon, icon_size);
+			image.set_size_request(icon_size, icon_size);
 			overlay.add(image);
 
 			notify["icon"].connect(() => {


### PR DESCRIPTION
Similar to acbd2aa942b4ff7fb43353330a54e13170c8c99b, this makes the action buttons smaller when using symbolic icons as well. With compatibility mode, I removed the play button and only show the compatibility icon.

I think this looks much better. The large icons doesn't look good with symbolic.

#### Elementary icons
![smaller-actionbutton](https://user-images.githubusercontent.com/515120/51079640-b2c57280-16ca-11e9-95a8-5a10ebf013cb.png)

#### Paper icons with light background and "Materia" theme
![lighter theme](https://user-images.githubusercontent.com/515120/51079893-e1dee280-16d0-11e9-8a6c-01f6dd7bfcf1.png)


Unfortunately it doesn't update the size when you change the setting. I didn't figure out how to do that (maybe this is the `ui_settings.notify` part?)
