### PR TITLE
Make overlays remountable

### DIFF
--- a/src/utils/FSOverlay.vala
+++ b/src/utils/FSOverlay.vala
@@ -65,7 +65,7 @@ namespace GameHub.Utils
 					overlay_dirs += overlays.get(i).get_path();
 				}
 
-				options_arr += "lowerdir=" + string.joinv(":", overlay_dirs);
+				options_arr += "index=off,lowerdir=" + string.joinv(":", overlay_dirs);
 
 				if(persist != null && workdir != null)
 				{


### PR DESCRIPTION
Remounting fails because of left over index folder. Giving `index=off` as the error message suggests fixes the problem.
See #120 for more information.

[This will change the behavior to a non POSIX compliant filesystem](https://www.kernel.org/doc/Documentation/filesystems/overlayfs.txt):

> Non-standard behavior
> ---------------------
> 
> Overlayfs can now act as a POSIX compliant filesystem with the following features turned on:
> 
> […]
> 
> 2) "inode index"
> 
> Enabled with the mount option or module option "index=on" or with the kernel config option CONFIG_OVERLAY_FS_INDEX=y.
> 
> If this feature is disabled and a file with multiple hard links is copied up, then this will "break" the link.  Changes will not be propagated to other names referring to the same inode.