### PR TITLE
Add Proton 4.11

### DIFF
--- a/src/data/compat/Proton.vala
+++ b/src/data/compat/Proton.vala
@@ -24,7 +24,7 @@ namespace GameHub.Data.Compat
 {
 	public class Proton: Wine
 	{
-		public const string[] APPIDS = {"1054830", "996510", "961940", "930400", "858280"}; // 4.2, 3.16 Beta, 3.16, 3.7 Beta, 3.7
+		public const string[] APPIDS = {"1113280", "1054830", "996510", "961940", "930400", "858280"}; // 4.11, 4.2, 3.16 Beta, 3.16, 3.7 Beta, 3.7
 		public const string LATEST = "latest";
 
 		public string appid { get; construct; }


### PR DESCRIPTION
Haven't tested these changes yet, will do tomorrow.
There's also a new environment variable which may be interesting, don't know if it's worth adding to the settings window as it should be included into DXVK later anyway:
> Proton now ships with D9VK v0.13f. D9VK is an experimental Vulkan-based Direct3D 9 renderer. It must be enabled by the user with the `PROTON_USE_D9VK` user setting.

* https://github.com/ValveSoftware/Proton/wiki/Changelog#411-1
* https://steamdb.info/app/1113280/