### PR TITLE
Add innoextract as a hard dependency in deb package

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -14,12 +14,13 @@ Build-Depends: meson (>= 0.40),
                libsqlite3-dev,
                libxml2-dev,
                libpolkit-gobject-1-dev,
-               libx11-dev, libmanette-0.2-dev, libxtst-dev
+               libx11-dev, libmanette-0.2-dev, libxtst-dev,
+               innoextract
 Standards-Version: 4.1.4
 
 Package: com.github.tkashkin.gamehub
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}
-Recommends: file-roller, innoextract, wine, dosbox
+Recommends: file-roller, wine, dosbox
 Suggests: steam
 Description: All your games in one place


### PR DESCRIPTION
My GOG games don't install without innoextract. Took some digging in the closed issues to figure out what was wrong. So I'm suggesting this minor patch.