### PR TITLE
Tweak tweaks

### DIFF
--- a/compat/dxvk.json
+++ b/compat/dxvk.json
@@ -1,0 +1,209 @@
+[
+	{
+		"id": "dxvk_hud",
+		"name": "Show HUD",
+		"description": "Enable DXVK HUD",
+		"url": "https://github.com/doitsujin/dxvk#hud",
+		"group": "DXVK",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["wine", "proton"]
+		},
+		"env": {
+			"DXVK_HUD": "${option:hud}"
+		},
+		"options": {
+			"hud": {
+				"name": "HUD elements",
+				"description": "Select HUD elements to show",
+				"type": "list",
+				"values": {
+					"devinfo": "Show name of GPU and driver version",
+					"fps": "Show frame rate",
+					"frametimes": "Show a frame time graph",
+					"submissions": "Show number of command buffers submitted per frame",
+					"drawcalls": "Show number of draw calls and render passes per frame",
+					"pipelines": "Show total number of graphics and compute pipelines",
+					"memory": "Show amount of device memory allocated and used",
+					"gpuload": "Show estimated GPU load. May be inaccurate",
+					"version": "Show DXVK version",
+					"api": "Show D3D feature level used by the application",
+					"compiler": "Show shader compiler activity",
+					"samplers": "Show current number of sampler pairs used (D3D9 only)"
+				},
+				"presets": {
+					"default": {
+						"name": "Default",
+						"description": "Show name of GPU, driver version and frame rate",
+						"value": "1"
+					},
+					"full": {
+						"name": "Full",
+						"description": "Show all available HUD elements",
+						"value": "full"
+					}
+				}
+			}
+		}
+	},
+	{
+		"id": "dxvk_device_filter",
+		"name": "Device filter",
+		"description": "Selects devices with a matching Vulkan device name, which can be retrieved with tools such as vulkaninfo.",
+		"url": "https://github.com/doitsujin/dxvk#device-filter",
+		"group": "DXVK",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["wine", "proton"]
+		},
+		"env": {
+			"DXVK_FILTER_DEVICE_NAME": "${option:name}"
+		},
+		"options": {
+			"name": {
+				"name": "Device Name",
+				"description": "Matches on substrings, so \"VEGA\" or \"AMD RADV VEGA10\" is supported if the full device name is \"AMD RADV VEGA10 (LLVM 9.0.0)\", for example. If the substring matches more than one device, the first device matched will be used.",
+				"type": "string"
+			}
+		}
+	},
+	{
+		"id": "dxvk_cache",
+		"name": "Disable state cache",
+		"description": "",
+		"url": "https://github.com/doitsujin/dxvk#state-cache",
+		"group": "DXVK",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["wine", "proton"]
+		},
+		"env": {
+			"DXVK_STATE_CACHE": "0"
+		}
+	},
+	{
+		"id": "dxvk_cache_path",
+		"name": "Cache files path",
+		"description": "Defaults to the current working directory of the application.",
+		"url": "https://github.com/doitsujin/dxvk#state-cache",
+		"group": "DXVK",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["wine", "proton"]
+		},
+		"env": {
+			"DXVK_STATE_CACHE_PATH": "${option:path}"
+		},
+		"options": {
+			"path": {
+				"name": "Directory where to put the cache files",
+				"description": "Defaults to the current working directory of the application.",
+				"type": "string",
+				"presets": {
+					"default": {
+						"name": "Default",
+						"value": ""
+					}
+				}
+			}
+		}
+	},
+	{
+		"id": "dxvk_debugging",
+		"name": "Debugging: Enable Vulkan debug layers",
+		"description": "Highly recommended for troubleshooting rendering issues and driver crashes. Requires the Vulkan SDK to be installed on the host system.",
+		"url": "https://github.com/doitsujin/dxvk#debugging",
+		"group": "DXVK",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["wine", "proton"]
+		},
+		"env": {
+			"VK_INSTANCE_LAYERS": "VK_LAYER_KHRONOS_validation"
+		}
+	},
+	{
+		"id": "dxvk_logging",
+		"name": "Message logging level",
+		"description": "Controls message logging",
+		"url": "https://github.com/doitsujin/dxvk#debugging",
+		"group": "DXVK",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["wine", "proton"]
+		},
+		"env": {
+			"DXVK_LOG_LEVEL": "${option:level}",
+			"DXVK_LOG_PATH": "${option:path}"
+		},
+		"options": {
+			"level": {
+				"name": "Logging level",
+				"presets": {
+					"none": {
+						"name": "None",
+						"value": "none"
+					},
+					"error": {
+						"name": "Error",
+						"value": "error"
+					},
+					"warn": {
+						"name": "Warning",
+						"value": "warn"
+					},
+					"info": {
+						"name": "Information",
+						"value": "info"
+					},
+					"debug": {
+						"name": "Debugging",
+						"value": "debug"
+					}
+				}
+			},
+			"path": {
+				"name": "Log file path",
+				"description": "Changes path where log files are stored.",
+				"type": "string",
+				"presets": {
+					"default": {
+						"name": "Default",
+						"value": ""
+					},
+					"none": {
+						"name": "None",
+						"value": "none"
+					}
+				}
+			}
+		}
+	},
+	{
+		"id": "dxvk_config_path",
+		"name": "Config file path",
+		"description": "Sets path to the configuration file.",
+		"url": "https://github.com/doitsujin/dxvk#debugging",
+		"group": "DXVK",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["wine", "proton"]
+		},
+		"env": {
+			"DXVK_CONFIG_FILE": "${option:path}"
+		},
+		"options": {
+			"path": {
+				"name": "Directory where to put the cache files",
+				"description": "Defaults to the current working directory of the application.",
+				"type": "string",
+				"presets": {
+					"default": {
+						"name": "Default",
+						"value": ""
+					}
+				}
+			}
+		}
+	}
+]

--- a/compat/proton.json
+++ b/compat/proton.json
@@ -1,0 +1,171 @@
+[
+	{
+		"id": "proton_dbg_cmds",
+		"name": "Dump debug commands",
+		"description": "When running a game, Proton will write some useful debug scripts for that game into $PROTON_DEBUG_DIR/proton_$USER/.",
+		"url": "https://github.com/ValveSoftware/Proton#runtime-config-options",
+		"group": "Proton",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["proton"]
+		},
+		"env": {
+			"PROTON_DUMP_DEBUG_COMMANDS": "1",
+			"PROTON_DEBUG_DIR": "${option:dir}"
+		},
+		"options": {
+			"dir": {
+				"name": "Directory for debug scripts",
+				"description": "Root directory for the Proton debug scripts.",
+				"type": "string",
+				"presets": {
+					"default": {
+						"name": "Default",
+						"description": "/tmp",
+						"value": "/tmp"
+					}
+				}
+			}
+		}
+	},
+	{
+		"id": "proton_dx_wined3d",
+		"name": "Use WineD3D",
+		"description": "Use OpenGL-based WineD3D for D3D11, D3D10 and D3D9 instead of Vulkan-based DXVK",
+		"url": "https://github.com/ValveSoftware/Proton#runtime-config-options",
+		"group": "Proton",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["proton"]
+		},
+		"env": {
+			"PROTON_USE_WINED3D": "1"
+		}
+	},
+	{
+		"id": "proton_dx_disable_d3d11",
+		"name": "Disable D3D11",
+		"description": "Disable d3d11.dll, for D3D11 games which can fall back to and run better with D3D9",
+		"url": "https://github.com/ValveSoftware/Proton#runtime-config-options",
+		"group": "Proton",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["proton"]
+		},
+		"env": {
+			"PROTON_NO_D3D11": "1"
+		}
+	},
+	{
+		"id": "proton_dx_disable_d3d10",
+		"name": "Disable D3D10",
+		"description": "Disable d3d10.dll and dxgi.dll, for D3D10 games which can fall back to and run better with D3D9",
+		"url": "https://github.com/ValveSoftware/Proton#runtime-config-options",
+		"group": "Proton",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["proton"]
+		},
+		"env": {
+			"PROTON_NO_D3D10": "1"
+		}
+	},
+	{
+		"id": "proton_no_esync",
+		"name": "Disable esync",
+		"description": "Disable eventfd-based in-process synchronization primitives",
+		"url": "https://github.com/ValveSoftware/Proton#runtime-config-options",
+		"group": "Proton",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["proton"]
+		},
+		"env": {
+			"PROTON_NO_ESYNC": "1"
+		}
+	},
+	{
+		"id": "proton_no_fsync",
+		"name": "Disable fsync",
+		"description": "Disable futex-based in-process synchronization primitives",
+		"url": "https://github.com/ValveSoftware/Proton#runtime-config-options",
+		"group": "Proton",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["proton"]
+		},
+		"env": {
+			"PROTON_NO_FSYNC": "1"
+		}
+	},
+	{
+		"id": "proton_no_laa",
+		"name": "Disable LARGE_ADDRESS_AWARE",
+		"description": "Disable Wines LARGE_ADDRESS_AWARE flag for all executables",
+		"url": "https://github.com/ValveSoftware/Proton#runtime-config-options",
+		"group": "Proton",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["proton"]
+		},
+		"env": {
+			"PROTON_FORCE_LARGE_ADDRESS_AWARE": "0"
+		}
+	},
+	{
+		"id": "proton_old_gl",
+		"name": "Use old GL strings",
+		"description": "Set some driver overrides to limit the length of the GL extension string, for old games that crash on very long extension strings",
+		"url": "https://github.com/ValveSoftware/Proton#runtime-config-options",
+		"group": "Proton",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["proton"]
+		},
+		"env": {
+			"PROTON_OLD_GL_STRING": "1"
+		}
+	},
+	{
+		"id": "proton_int_scale",
+		"name": "Use integer scaling",
+		"description": "Enable integer scaling mode, to give sharp pixels when upscaling",
+		"url": "https://github.com/ValveSoftware/Proton#runtime-config-options",
+		"group": "Proton",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["proton"]
+		},
+		"env": {
+			"WINE_FULLSCREEN_INTEGER_SCALING": "1"
+		}
+	},
+	{
+		"id": "proton_seccomp",
+		"name": "Enable seccomp-bpf",
+		"description": "Enable seccomp-bpf filter to emulate native syscalls, required for some DRM protections to work",
+		"url": "https://github.com/ValveSoftware/Proton#runtime-config-options",
+		"group": "Proton",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["proton"]
+		},
+		"env": {
+			"PROTON_USE_SECCOMP": "1"
+		}
+	},
+	{
+		"id": "proton_nww",
+		"name": "Disable support for memory write watches in ntdll.",
+		"description": "This is a very dangerous hack and should only be applied if you have verified that the game can operate without write watches. This improves performance for some very specific games (e.g. CoreRT-based games).",
+		"url": "https://github.com/ValveSoftware/Proton#runtime-config-options",
+		"group": "Proton",
+		"applicable_to": {
+			"platforms": ["windows"],
+			"compat": ["proton"]
+		},
+		"env": {
+			"PROTON_NO_WRITE_WATCH": "1"
+		}
+	}
+]

--- a/gpu/amd.json
+++ b/gpu/amd.json
@@ -1,0 +1,30 @@
+[
+	{
+		"id": "gpu_amd_vulkan_aco",
+		"name": "AMD: Radeon ACO Vulkan Compiler",
+		"description": "Enable ACO based Vulkan shader compiler for RADV instead of LLVM",
+		"url": "https://github.com/mesa3d/mesa",
+		"icon": "hardware-gpu-amd-symbolic",
+		"group": "GPU",
+		"requires": {
+			"kernel_modules": ["amdgpu"]
+		},
+		"env": {
+			"RADV_PERFTEST": "aco"
+		}
+	},
+	{
+		"id": "gpu_amd_glthread",
+		"name": "AMD: Threaded Optimizations",
+		"description": "Offload CPU computations to a worker thread",
+		"url": "https://github.com/mesa3d/mesa",
+		"icon": "hardware-gpu-amd-symbolic",
+		"group": "GPU",
+		"requires": {
+			"kernel_modules": ["amdgpu"]
+		},
+		"env": {
+			"mesa_glthread": "true"
+		}
+	}
+]

--- a/gpu/nvidia.json
+++ b/gpu/nvidia.json
@@ -1,0 +1,30 @@
+[
+	{
+		"id": "gpu_nvidia_glthread",
+		"name": "NVIDIA: Threaded Optimizations",
+		"description": "Offload CPU computations to a worker thread",
+		"url": "https://download.nvidia.com/XFree86/Linux-x86_64/410.104/README/openglenvvariables.html",
+		"icon": "hardware-gpu-nvidia-symbolic",
+		"group": "GPU",
+		"requires": {
+			"kernel_modules": ["nvidia"]
+		},
+		"env": {
+			"__GL_THREADED_OPTIMIZATIONS": "1"
+		}
+	},
+	{
+		"id": "gpu_nvidia_osd",
+		"name": "NVIDIA: Graphics API Visual Indicator",
+		"description": "Control whether the graphics API visual indicator is rendered on top of OpenGL and Vulkan applications",
+		"url": "https://download.nvidia.com/XFree86/Linux-x86_64/410.104/README/openglenvvariables.html",
+		"icon": "hardware-gpu-nvidia-symbolic",
+		"group": "Overlays",
+		"requires": {
+			"kernel_modules": ["nvidia"]
+		},
+		"env": {
+			"__GL_SHOW_GRAPHICS_OSD": "1"
+		}
+	}
+]

--- a/overlays/mangohud.json
+++ b/overlays/mangohud.json
@@ -1,0 +1,203 @@
+{
+	"id": "mangohud",
+	"name": "MangoHud",
+	"description": "A modification of the Mesa Vulkan overlay. Including GUI improvements, temperature reporting, and logging capabilities",
+	"url": "https://github.com/flightlessmango/MangoHud",
+	"group": "Overlays",
+	"requires": {
+		"executables": ["mangohud"]
+	},
+	"command": "mangohud ${command}",
+	"env": {
+		"MANGOHUD_CONFIG": "${option:read_cfg},${option:hud},${option:media_player},${option:vsync},${option:gl_vsync},${option:position},${option:fps_limit}"
+	},
+	"options": {
+		"hud": {
+			"name": "HUD elements",
+			"description": "Select HUD elements to show",
+			"type": "list",
+			"values": {
+				"arch": "Show if the application is 32 or 64 bit",
+				"core_load": "Display CPU load and frequency per core",
+				"cpu_stats=0": "Hide CPU information",
+				"cpu_temp": "Display current CPU temperature",
+				"engine_version": "Display OpenGL or Vulkan and Vulkan-based render engine's version",
+				"frame_timing=0": "Hide the frame timing graph",
+				"gpu_stats=0": "Hide GPU information",
+				"gpu_temp": "Display current GPU temperature",
+				"gpu_core_clock": "Display GPU core frequency",
+				"gpu_mem_clock": "Display GPU memory frequency",
+				"histogram": "Change FPS graph to histogram",
+				"io_read": "IO read for the app (not system)",
+				"io_write": "IO write for the app (not system)",
+				"no_display": "Disable / hide the HUD by default",
+				"ram": "Display system RAM usage",
+				"time": "Display the current system time",
+				"vram": "Display system VRAM usage",
+				"version": "Display MangoHud version",
+				"vulkan_driver": "Display current Vulkan driver"
+			},
+			"presets": {
+				"default": {
+					"name": "Default",
+					"value": ""
+				},
+				"full": {
+					"name": "Full",
+					"description": "Enables most of the toggleable parameters",
+					"value": "full"
+				}
+			}
+		},
+		"media_player": {
+			"name": "Media player",
+			"description": "Display a media player",
+			"type": "string",
+			"value": "media_player,media_player_name=${value}",
+			"presets": {
+				"default": {
+					"name": "Default",
+					"value": ""
+				},
+				"spotify": {
+					"name": "Spotify",
+					"value": "media_player,media_player_name=spotify"
+				},
+				"audacious": {
+					"name": "Audacious",
+					"value": "media_player,media_player_name=audacious"
+				},
+				"cantata": {
+					"name": "Cantata",
+					"value": "media_player,media_player_name=cantata"
+				},
+				"vlc": {
+					"name": "VLC",
+					"value": "media_player,media_player_name=vlc"
+				}
+			}
+		},
+		"vsync": {
+			"name": "VSync (Vulkan)",
+			"presets": {
+				"default": {
+					"name": "Default",
+					"value": ""
+				},
+				"0": {
+					"name": "Adaptive VSync",
+					"description": "Tearing at low framerates",
+					"value": "vsync=0"
+				},
+				"1": {
+					"name": "Force off",
+					"value": "vsync=1"
+				},
+				"2": {
+					"name": "Mailbox mode",
+					"description": "VSync with uncapped framerate",
+					"value": "vsync=2"
+				},
+				"3": {
+					"name": "Traditional VSync",
+					"description": "Frame rate capped to refresh rate",
+					"value": "vsync=3"
+				}
+			}
+		},
+		"gl_vsync": {
+			"name": "VSync (OpenGL)",
+			"presets": {
+				"off": {
+					"name": "Off",
+					"value": "gl_vsync=off"
+				},
+				"1": {
+					"name": "Display refresh rate",
+					"value": "gl_vsync=1"
+				},
+				"2": {
+					"name": "Half of display refresh rate",
+					"value": "gl_vsync=2"
+				},
+				"4": {
+					"name": "Quarter of display refresh rate",
+					"value": "gl_vsync=4"
+				}
+			}
+		},
+		"position": {
+			"name": "HUD position",
+			"presets": {
+				"top-left": {
+					"name": "top-left",
+					"value": "position=top-left"
+				},
+				"top-right": {
+					"name": "top-right",
+					"value": "position=top-right"
+				},
+				"bottom-left": {
+					"name": "bottom-left",
+					"value": "position=bottom-left"
+				},
+				"bottom-right": {
+					"name": "bottom-right",
+					"value": "position=bottom-right"
+				},
+				"top-center": {
+					"name": "top-center",
+					"value": "position=top-center"
+				}
+			}
+		},
+		"fps_limit": {
+			"name": "Frame rate limit",
+			"type": "string",
+			"value": "fps_limit=${value}",
+			"presets": {
+				"default": {
+					"name": "Unlimited",
+					"value": ""
+				},
+				"240": {
+					"name": "240 FPS",
+					"value": "fps_limit=240"
+				},
+				"144": {
+					"name": "144 FPS",
+					"value": "fps_limit=144"
+				},
+				"120": {
+					"name": "120 FPS",
+					"value": "fps_limit=120"
+				},
+				"100": {
+					"name": "100 FPS",
+					"value": "fps_limit=100"
+				},
+				"60": {
+					"name": "60 FPS",
+					"value": "fps_limit=60"
+				},
+				"30": {
+					"name": "30 FPS",
+					"value": "fps_limit=30"
+				}
+			}
+		},
+		"read_cfg": {
+			"name": "Config files",
+			"presets": {
+				"default": {
+					"name": "Default",
+					"value": ""
+				},
+				"read_cfg": {
+					"name": "Load config files in addition to options",
+					"value": "read_cfg"
+				}
+			}
+		}
+	}
+}

--- a/overlays/mumble.json
+++ b/overlays/mumble.json
@@ -1,0 +1,11 @@
+{
+	"id": "mumble",
+	"name": "Mumble",
+	"description": "Overlay the nicknames of users over your game",
+	"url": "https://wiki.mumble.info/wiki/Overlay",
+	"group": "Overlays",
+	"requires": {
+		"executables": ["mumble-overlay"]
+	},
+	"command": "mumble-overlay ${command}"
+}

--- a/performance/gamemode.json
+++ b/performance/gamemode.json
@@ -1,0 +1,11 @@
+{
+	"id": "gamemode",
+	"name": "Feral GameMode",
+	"description": "Temporarily apply a set of optimizations to a game process and OS",
+	"url": "https://github.com/FeralInteractive/gamemode",
+	"group": "Performance",
+	"requires": {
+		"executables": ["gamemoderun"]
+	},
+	"command": "gamemoderun ${command}"
+}

--- a/performance/libstrangle.json
+++ b/performance/libstrangle.json
@@ -1,0 +1,424 @@
+[
+	{
+		"id": "libstrangle",
+		"name": "libstrangle",
+		"description": "Frame rate limiter for Linux",
+		"url": "https://gitlab.com/torkel104/libstrangle",
+		"group": "Performance",
+		"requires": {
+			"executables": ["strangle"]
+		},
+		"command": "strangle ${command}",
+		"env": {
+			"STRANGLE_FPS": "${option:fps}",
+			"STRANGLE_FPS_BATTERY": "${option:fps_battery}",
+			"STRANGLE_VSYNC": "${option:vsync}",
+			"STRANGLE_GLFINISH": "${option:glfinish}",
+			"STRANGLE_PICMIP": "${option:picmip}",
+			"STRANGLE_AF": "${option:af}",
+			"STRANGLE_TRILINEAR": "${option:trilinear}",
+			"STRANGLE_RETRO": "${option:retro}",
+			"STRANGLE_NODLSYM": "${option:nodlsym}",
+			"STRANGLE_VKONLY": "${option:vkonly}"
+		},
+		"options": {
+			"fps": {
+				"name": "Frame rate limit",
+				"description": "Maximum frame rate",
+				"type": "string",
+				"presets": {
+					"default": {
+						"name": "Unlimited",
+						"value": "0"
+					},
+					"240": {
+						"name": "240 FPS",
+						"value": "240"
+					},
+					"144": {
+						"name": "144 FPS",
+						"value": "144"
+					},
+					"120": {
+						"name": "120 FPS",
+						"value": "120"
+					},
+					"100": {
+						"name": "100 FPS",
+						"value": "100"
+					},
+					"60": {
+						"name": "60 FPS",
+						"value": "60"
+					},
+					"30": {
+						"name": "30 FPS",
+						"value": "30"
+					}
+				}
+			},
+			"fps_battery": {
+				"name": "Frame rate limit (battery)",
+				"description": "Maximum frame rate when running on battery power",
+				"type": "string",
+				"presets": {
+					"default": {
+						"name": "Unlimited",
+						"value": "0"
+					},
+					"240": {
+						"name": "240 FPS",
+						"value": "240"
+					},
+					"144": {
+						"name": "144 FPS",
+						"value": "144"
+					},
+					"120": {
+						"name": "120 FPS",
+						"value": "120"
+					},
+					"100": {
+						"name": "100 FPS",
+						"value": "100"
+					},
+					"60": {
+						"name": "60 FPS",
+						"value": "60"
+					},
+					"30": {
+						"name": "30 FPS",
+						"value": "30"
+					}
+				}
+			},
+			"vsync": {
+				"name": "VSync",
+				"description": "Set VSync for Vulkan and OpenGL",
+				"type": "string",
+				"presets": {
+					"default": {
+						"name": "Default",
+						"value": ""
+					},
+					"-1": {
+						"name": "OpenGL: Adaptive sync",
+						"value": "-1"
+					},
+					"0": {
+						"name": "OpenGL/Vulkan: Force off",
+						"value": "0"
+					},
+					"1": {
+						"name": "Vulkan: Mailbox mode - VSync with uncapped framerate",
+						"description": "OpenGL: Force on",
+						"value": "1"
+					},
+					"2": {
+						"name": "Vulkan: Traditional VSync with framerate capped to refresh rate",
+						"description": "OpenGL: Half of the display refresh rate",
+						"value": "2"
+					},
+					"3": {
+						"name": "Vulkan: Adaptive VSync with tearing at low framerates",
+						"description": "OpenGL: Third of the display refresh rate",
+						"value": "3"
+					},
+					"4": {
+						"name": "OpenGL: Quarter of the display refresh rate",
+						"value": "4"
+					}
+				}
+			},
+			"glfinish": {
+				"name": "glFinish()",
+				"description": "OpenGL only",
+				"presets": {
+					"0": {
+						"name": "Default",
+						"value": "0"
+					},
+					"1": {
+						"name": "Force glFinish() to run after every frame",
+						"value": "1"
+					}
+				}
+			},
+			"picmip": {
+				"name": "LOD bias",
+				"description": "Adjust Level of Detail for mip-maps",
+				"presets": {
+					"default": {
+						"name": "Default",
+						"value": ""
+					},
+					"-16": {
+						"name": "-16",
+						"description": "Most texture sharpness (and aliasing)",
+						"value": "-16"
+					},
+					"-15": {
+						"name": "-15",
+						"value": "-15"
+					},
+					"-14": {
+						"name": "-14",
+						"value": "-14"
+					},
+					"-13": {
+						"name": "-13",
+						"value": "-13"
+					},
+					"-12": {
+						"name": "-12",
+						"value": "-12"
+					},
+					"-11": {
+						"name": "-11",
+						"value": "-11"
+					},
+					"-10": {
+						"name": "-10",
+						"value": "-10"
+					},
+					"-9": {
+						"name": "-9",
+						"value": "-9"
+					},
+					"-8": {
+						"name": "-8",
+						"value": "-8"
+					},
+					"-7": {
+						"name": "-7",
+						"value": "-7"
+					},
+					"-6": {
+						"name": "-6",
+						"value": "-6"
+					},
+					"-5": {
+						"name": "-5",
+						"value": "-5"
+					},
+					"-4": {
+						"name": "-4",
+						"value": "-4"
+					},
+					"-3": {
+						"name": "-3",
+						"value": "-3"
+					},
+					"-2": {
+						"name": "-2",
+						"value": "-2"
+					},
+					"-1": {
+						"name": "-1",
+						"value": "-1"
+					},
+					"0": {
+						"name": "0",
+						"value": "0"
+					},
+					"1": {
+						"name": "1",
+						"value": "1"
+					},
+					"2": {
+						"name": "2",
+						"value": "2"
+					},
+					"3": {
+						"name": "3",
+						"value": "3"
+					},
+					"4": {
+						"name": "4",
+						"value": "4"
+					},
+					"5": {
+						"name": "5",
+						"value": "5"
+					},
+					"6": {
+						"name": "6",
+						"value": "6"
+					},
+					"7": {
+						"name": "7",
+						"value": "7"
+					},
+					"8": {
+						"name": "8",
+						"value": "8"
+					},
+					"9": {
+						"name": "9",
+						"value": "9"
+					},
+					"10": {
+						"name": "10",
+						"value": "10"
+					},
+					"11": {
+						"name": "11",
+						"value": "11"
+					},
+					"12": {
+						"name": "12",
+						"value": "12"
+					},
+					"13": {
+						"name": "13",
+						"value": "13"
+					},
+					"14": {
+						"name": "14",
+						"value": "14"
+					},
+					"15": {
+						"name": "15",
+						"value": "15"
+					},
+					"16": {
+						"name": "16",
+						"description": "Most texture blurriness",
+						"value": "16"
+					}
+				}
+			},
+			"af": {
+				"name": "Anisotropic filtering",
+				"description": "Improves sharpness of textures viewed at an angle (Vulkan only)",
+				"presets": {
+					"default": {
+						"name": "Default",
+						"value": ""
+					},
+					"1": {
+						"name": "1",
+						"value": "1"
+					},
+					"2": {
+						"name": "2",
+						"value": "2"
+					},
+					"3": {
+						"name": "3",
+						"value": "3"
+					},
+					"4": {
+						"name": "4",
+						"value": "4"
+					},
+					"5": {
+						"name": "5",
+						"value": "5"
+					},
+					"6": {
+						"name": "6",
+						"value": "6"
+					},
+					"7": {
+						"name": "7",
+						"value": "7"
+					},
+					"8": {
+						"name": "8",
+						"value": "8"
+					},
+					"9": {
+						"name": "9",
+						"value": "9"
+					},
+					"10": {
+						"name": "10",
+						"value": "10"
+					},
+					"11": {
+						"name": "11",
+						"value": "11"
+					},
+					"12": {
+						"name": "12",
+						"value": "12"
+					},
+					"13": {
+						"name": "13",
+						"value": "13"
+					},
+					"14": {
+						"name": "14",
+						"value": "14"
+					},
+					"15": {
+						"name": "15",
+						"value": "15"
+					},
+					"16": {
+						"name": "16",
+						"value": "16"
+					}
+				}
+			},
+			"trilinear": {
+				"name": "Trilinear filtering",
+				"description": "Vulkan only",
+				"presets": {
+					"0": {
+						"name": "Default",
+						"value": "0"
+					},
+					"1": {
+						"name": "Force trilinear filtering",
+						"value": "1"
+					}
+				}
+			},
+			"retro": {
+				"name": "Retro",
+				"description": "Disables linear texture filtering (Vulkan only)",
+				"presets": {
+					"0": {
+						"name": "Default",
+						"value": "0"
+					},
+					"1": {
+						"name": "Disable linear texture filtering",
+						"description": "Makes textures look blocky",
+						"value": "1"
+					}
+				}
+			},
+			"nodlsym": {
+				"name": "Disable dlsym",
+				"description": "Some programs will crash, freeze or behave unexpectedly when dlsym is hijacked",
+				"presets": {
+					"0": {
+						"name": "Default",
+						"value": "0"
+					},
+					"1": {
+						"name": "Disable the hooking of dlsym",
+						"value": "1"
+					}
+				}
+			},
+			"vkonly": {
+				"name": "Disable for OpenGL",
+				"presets": {
+					"0": {
+						"name": "Default",
+						"value": "0"
+					},
+					"1": {
+						"name": "Disable for OpenGL",
+						"description": "Stop strangle's OpenGL libs from loading",
+						"value": "1"
+					}
+				}
+			}
+		}
+	}
+]

--- a/postprocessing/vkbasalt.json
+++ b/postprocessing/vkbasalt.json
@@ -1,0 +1,85 @@
+[
+	{
+		"id": "vkbasalt",
+		"name": "vkBasalt",
+		"description": "Vulkan post processing layer to enhance the visual graphics of games",
+		"url": "https://github.com/DadSchoorse/vkBasalt",
+		"group": "Post-processing",
+		"env": {
+			"ENABLE_VKBASALT": "1",
+			"VKBASALT_CONFIG_FILE": "${option:config}"
+		}
+	},
+	{
+		"id": "vkbasalt_config",
+		"name": "vkBasalt: Configuration file",
+		"description": "Settings like the CAS sharpening strength can be changed in the config file.",
+		"url": "https://github.com/DadSchoorse/vkBasalt#configure",
+		"group": "Post-processing",
+		"env": {
+			"VKBASALT_CONFIG_FILE": "${option:config}"
+		},
+		"options": {
+			"config": {
+				"name": "Path to the configuration file",
+				"description": "/path/to/vkBasalt.conf",
+				"type": "string"
+			}
+		}
+	},
+	{
+		"id": "vkbasalt_debug",
+		"name": "vkBasalt: Debug output",
+		"description": "Set the amount and location of debug output",
+		"url": "https://github.com/DadSchoorse/vkBasalt#debug-output",
+		"group": "Post-processing",
+		"env": {
+			"VKBASALT_LOG_LEVEL": "${option:level}",
+			"VKBASALT_LOG_FILE": "${option:location}"
+		},
+		"options": {
+			"level": {
+				"name": "Debug level",
+				"description": "Amount of debug output",
+				"type": "string",
+				"presets": {
+					"none": {
+						"name": "None",
+						"value": "none"
+					},
+					"error": {
+						"name": "Error",
+						"value": "error"
+					},
+					"warn": {
+						"name": "Warning",
+						"value": "warn"
+					},
+					"info": {
+						"name": "Information",
+						"value": "info"
+					},
+					"debug": {
+						"name": "Debugging",
+						"value": "debug"
+					},
+					"trace": {
+						"name": "Trace",
+						"value": "trace"
+					}
+				}
+			},
+			"location": {
+				"name": "Output location",
+				"description": "Filename",
+				"type": "string",
+				"presets": {
+					"default": {
+						"name": "vkBasalt.log",
+						"value": "vkBasalt.log"
+					}
+				}
+			}
+		}
+	}
+]


### PR DESCRIPTION
Move dxvk options into its own file and fill both with a more complete option set.

Including all of these will clutter the tweak window _a lot_ so this needs some sort of grouping before merging.
While writing I've noticed the two options `1` and `full` which both can function as a master switch to hide the underlying grouped options like a sane default. Related to https://github.com/tkashkin/GameHub/issues/326#issuecomment-602233959

I can't get `PROTON_LOG=1` to work. The closest I get was by also setting `SteamGameId=gamehub` but this prevents proton from running without the steam client open.