### PR TITLE
Fix setting work_dir to install_dir

### DIFF
--- a/src/data/Game.vala
+++ b/src/data/Game.vala
@@ -342,7 +342,7 @@ namespace GameHub.Data
 					{
 						if(value.get_path().has_prefix(dir.get_path()))
 						{
-							work_dir_path = value.get_path().replace(dir.get_path(), "$game_dir");
+							work_dir_path = value.get_path().replace(dir.get_path(), "$game_dir/");
 							break;
 						}
 					}

--- a/src/data/Game.vala
+++ b/src/data/Game.vala
@@ -255,8 +255,11 @@ namespace GameHub.Data
 			{
 				if(from_all_overlays)
 				{
-					dirs += install_dir.get_child(FSUtils.GAMEHUB_DIR).get_child("_overlay").get_child("merged");
-					dirs += install_dir.get_child(FSUtils.GAMEHUB_DIR).get_child(FSUtils.OVERLAYS_DIR).get_child(Overlay.BASE);
+					dirs = {
+						install_dir.get_child(FSUtils.GAMEHUB_DIR).get_child("_overlay").get_child("merged"),
+						install_dir.get_child(FSUtils.GAMEHUB_DIR).get_child(FSUtils.OVERLAYS_DIR).get_child(Overlay.BASE),
+						install_dir
+					};
 					foreach(var overlay in overlays)
 					{
 						if(overlay.id == Overlay.BASE) continue;


### PR DESCRIPTION
When the given new `value` equals the iterated `dir` the `work_dir_path` was saved as `$game_dir` and on query tested against `$game_dir/` which resulted in the final path `$game_dir/$game_dir`:

https://github.com/tkashkin/GameHub/blob/ae211801176f60fb4d99e1753f236496f872838f/src/data/Game.vala#L326

https://github.com/tkashkin/GameHub/blob/ae211801176f60fb4d99e1753f236496f872838f/src/data/Game.vala#L245-L252

Fix #358