### PR TITLE
Add steam image provider

### DIFF
--- a/data/com.github.tkashkin.gamehub.gschema.xml.in
+++ b/data/com.github.tkashkin.gamehub.gschema.xml.in
@@ -325,10 +325,6 @@
 				<default>true</default>
 				<summary>Is Steam image search enabled</summary>
 			</key>
-			<key name="api-key" type="s">
-				<default>'@PREF_API_KEY_STEAM@'</default>
-				<summary>Steam API key</summary>
-			</key>
 		</schema>
 
 	<!-- Providers / Data / IGDB -->

--- a/data/com.github.tkashkin.gamehub.gschema.xml.in
+++ b/data/com.github.tkashkin.gamehub.gschema.xml.in
@@ -320,6 +320,17 @@
 			</key>
 		</schema>
 
+		<schema path="@SCHEMA_PATH@/providers/images/steam/" id="@SCHEMA_ID@.providers.images.steam">
+			<key name="enabled" type="b">
+				<default>true</default>
+				<summary>Is Steam image search enabled</summary>
+			</key>
+			<key name="api-key" type="s">
+				<default>'@PREF_API_KEY_STEAM@'</default>
+				<summary>Steam API key</summary>
+			</key>
+		</schema>
+
 	<!-- Providers / Data / IGDB -->
 		<enum id="@SCHEMA_ID@.providers.data.igdb.preferred-description">
 			<value nick="Game" value="0" />

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -49,6 +49,7 @@ src/data/adapters/GamesAdapter.vala
 src/data/providers/Provider.vala
 src/data/providers/ImagesProvider.vala
 src/data/providers/DataProvider.vala
+src/data/providers/images/Steam.vala
 src/data/providers/images/SteamGridDB.vala
 src/data/providers/images/JinxSGVI.vala
 src/data/providers/data/IGDB.vala

--- a/src/app.vala
+++ b/src/app.vala
@@ -143,7 +143,7 @@ namespace GameHub
 
 			GameSources = { new Steam(), new GOG(), new Humble(), new Trove(), new Itch(), new User() };
 
-			Providers.ImageProviders = { new Providers.Images.SteamGridDB(), new Providers.Images.JinxSGVI() };
+			Providers.ImageProviders = { new Providers.Images.Steam(), new Providers.Images.SteamGridDB(), new Providers.Images.JinxSGVI() };
 			Providers.DataProviders  = { new Providers.Data.IGDB() };
 
 			var proton_latest = new Compat.Proton(Compat.Proton.LATEST);

--- a/src/data/providers/images/Steam.vala
+++ b/src/data/providers/images/Steam.vala
@@ -1,0 +1,265 @@
+/*
+This file is part of GameHub.
+Copyright (C) 2018-2019 Anatoliy Kashkin
+
+GameHub is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+GameHub is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GameHub.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+using Gee;
+using GameHub.Utils;
+
+namespace GameHub.Data.Providers.Images
+{
+	public class Steam: ImagesProvider
+	{
+		private const string DOMAIN       = "https://store.steampowered.com/";
+		private const string CDN_BASE_URL     = "http://cdn.akamai.steamstatic.com/steam/apps/";
+		private const string API_KEY_PAGE = "https://steamcommunity.com/dev/apikey";
+		private const string API_BASE_URL = "https://api.steampowered.com/";
+
+		//  private const string APPLIST_CACHE_PATH = @"$(FSUtils.Paths.Cache.Providers)/steam/";
+		private const string APPLIST_CACHE_FILE = "applist.json";
+
+		private ImagesProvider.ImageSize?[] SIZES = { ImageSize(460, 215), ImageSize(600, 900) };
+
+		public override string id   { get { return "steam"; } }
+		public override string name { get { return "Steam"; } }
+		public override string url  { get { return DOMAIN; } }
+		public override string icon { get { return "source-steam-symbolic"; } }
+
+		public override bool enabled
+		{
+			get { return Settings.Providers.Images.Steam.instance.enabled; }
+			set { Settings.Providers.Images.Steam.instance.enabled = value; }
+		}
+
+		public override async ArrayList<ImagesProvider.Result> images(Game game)
+		{
+			var results = new ArrayList<ImagesProvider.Result>();
+			var app_id = "";
+
+			if(game is GameHub.Data.Sources.Steam.SteamGame)
+			{
+				app_id = game.id;
+			}
+			else
+			{
+				app_id = yield get_appid(game.name);
+			}
+
+			if(app_id != "")
+			{
+				foreach(var size in SIZES)
+				{
+					var needs_check = false;
+					var exists = false;
+					var result = new ImagesProvider.Result();
+					result.image_size = size ?? ImageSize(460, 215);
+					result.name = "%s: %s (%d × %d)".printf(name, game.name, result.image_size.width, result.image_size.height);
+					result.url = "%sapp/%s".printf(DOMAIN, app_id);
+
+					var format = "header.jpg";
+					switch (size.width) {
+					case 460:
+						// Always enforced by steam, exists for everything
+						format = "header.jpg";
+						exists = true;
+						break;
+					//  case 920:
+						// Higher resolution of the one above at the same location
+						//  format = "header.jpg";
+						//  break;
+					case 600:
+						// Enforced since 2019, possibly not available
+						format = "library_600x900_2x.jpg";
+						needs_check = true;
+						break;
+					}
+
+					var endpoint = "%s/%s".printf(app_id, format);
+
+					result.images = new ArrayList<ImagesProvider.Image>();
+
+					if(needs_check)
+					{
+						exists = yield image_exists("%s%s".printf(CDN_BASE_URL, endpoint));
+					}
+
+					if(exists)
+					{
+						result.images.add(new Image("%s%s".printf(CDN_BASE_URL, endpoint)));
+					}
+
+					if(result.images.size > 0)
+					{
+						results.add(result);
+					}
+				}
+			}
+
+			return results;
+		}
+
+		private async bool image_exists(string url)
+		{
+			uint status;
+			yield Parser.load_remote_file_async(url, "GET", null, null, null, out status);
+			if(status == 200)
+			{
+				return true;
+			}
+			return false;
+		}
+
+		private async string get_appid(string name)
+		{
+			var applist_cache_path = @"$(FSUtils.Paths.Cache.Providers)/steam/";
+			var cache_file = FSUtils.file(applist_cache_path, APPLIST_CACHE_FILE);
+			DateTime? modification_date = null;
+
+			if(cache_file.query_exists())
+			{
+				try
+				{
+					// Get modification time so we refresh only once a day or we get blocked really fast.
+					modification_date = cache_file.query_info("*", NONE).get_modification_date_time();
+				}
+				catch(Error e)
+				{
+					debug("[Provider.Images.Steam] %s", e.message);
+					return "";
+				}
+			}
+
+			if(!cache_file.query_exists() || modification_date == null || modification_date.compare(new DateTime.now_utc().add_days(-1)) < 0)
+			{
+				// https://api.steampowered.com/ISteamApps/GetAppList/v0002/?key=
+				var url = @"$(API_BASE_URL)ISteamApps/GetAppList/v0002/?key=$(Settings.Providers.Images.Steam.instance.api_key)";
+
+				FSUtils.mkdir(applist_cache_path);
+				cache_file = FSUtils.file(applist_cache_path, APPLIST_CACHE_FILE);
+
+				// https://stackoverflow.com/a/18077010
+				try
+				{
+					var dos = new DataOutputStream(cache_file.replace(null, false, FileCreateFlags.NONE));
+					var json_string = yield Parser.load_remote_file_async(url);
+					dos.put_string(json_string);
+				}
+				catch(Error e)
+				{
+					warning("[Provider.Images.Steam] %s", e.message);
+					return "";
+				}
+
+				debug("[Provider.Images.Steam] Refreshed steam applist");
+			}
+
+			var json = Parser.parse_json_file(applist_cache_path, APPLIST_CACHE_FILE);
+			if(json == null || json.get_node_type() != Json.NodeType.OBJECT)
+			{
+				return "";
+			}
+
+			try
+			{
+				// https://goessner.net/articles/JsonPath/
+				//  var apps = Json.Path.query("$.applist.apps[*]", json);
+				//  var appid = "";
+				//  apps.get_array().foreach_element((obj, i, app) => {
+				//  	if(appid == "" && app.get_object().get_string_member("name") == name)
+				//  	{
+				//  		appid = app.get_object().get_int_member("appid").to_string();
+				//  		debug("[Provider.Images.Steam] Found appid %s for game %s", appid, name);
+				//  	}
+				//  });
+
+				//  return appid;
+
+				var apps = json.get_object().get_object_member("applist").get_array_member("apps").get_elements();
+				foreach(var app in apps)
+				{
+					// exact match, maybe do some fuzzy matching?
+					if(app.get_object().get_string_member("name") == name)
+					{
+						var appid = app.get_object().get_int_member("appid").to_string();
+						debug("[Provider.Images.Steam] Found appid %s for game %s", appid, name);
+						return appid;
+					}
+				}
+			}
+			catch(Error e)
+			{
+				warning("[Provider.Images.Steam] %s", e.message);
+				return "";
+			}
+
+			return "";
+		}
+
+		public override Gtk.Widget? settings_widget
+		{
+			owned get
+			{
+				var settings = Settings.Providers.Images.Steam.instance;
+
+				var grid = new Gtk.Grid();
+				grid.column_spacing = 12;
+				grid.row_spacing = 4;
+
+				var entry = new Gtk.Entry();
+				entry.placeholder_text = _("Default");
+				entry.max_length = 32;
+				if(settings.api_key != settings.schema.get_default_value("api-key").get_string())
+				{
+					entry.text = settings.api_key;
+				}
+				entry.secondary_icon_name = "edit-delete-symbolic";
+				entry.secondary_icon_tooltip_text = _("Restore default API key");
+				entry.set_size_request(250, -1);
+
+				entry.notify["text"].connect(() => { settings.api_key = entry.text; });
+				entry.icon_press.connect((pos, e) => {
+					if(pos == Gtk.EntryIconPosition.SECONDARY)
+					{
+						entry.text = "";
+					}
+				});
+
+				var label = new Gtk.Label(_("API key"));
+				label.halign = Gtk.Align.START;
+				label.valign = Gtk.Align.CENTER;
+				label.hexpand = true;
+
+				var entry_wrapper = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
+				entry_wrapper.get_style_context().add_class(Gtk.STYLE_CLASS_LINKED);
+
+				var link = new Gtk.Button.with_label(_("Generate key"));
+				link.tooltip_text = API_KEY_PAGE;
+
+				link.clicked.connect(() => {
+					Utils.open_uri(API_KEY_PAGE);
+				});
+
+				entry_wrapper.add(entry);
+				entry_wrapper.add(link);
+
+				grid.attach(label, 0, 0);
+				grid.attach(entry_wrapper, 1, 0);
+
+				return grid;
+			}
+		}
+	}
+}

--- a/src/data/sources/steam/Steam.vala
+++ b/src/data/sources/steam/Steam.vala
@@ -318,6 +318,45 @@ namespace GameHub.Data.Sources.Steam
 			return pkgs;
 		}
 
+		public static async string? get_appid_from_name(string game_name)
+		{
+			if(instance == null) return null;
+
+			instance.load_appinfo();
+
+			if(instance.appinfo == null) return null;
+
+			foreach(var app_node in instance.appinfo.nodes.values)
+			{
+				if(app_node != null && app_node is BinaryVDF.ListNode)
+				{
+					var app = (BinaryVDF.ListNode) app_node;
+					var common_node = app.get_nested({"appinfo", "common"});
+
+					if(common_node != null && common_node is BinaryVDF.ListNode)
+					{
+						var common = (BinaryVDF.ListNode) common_node;
+
+						var name_node = common.get("name");
+						var type_node = common.get("type");
+
+						if(name_node != null && name_node is BinaryVDF.StringNode && type_node != null && type_node is BinaryVDF.StringNode)
+						{
+							var name = ((BinaryVDF.StringNode) name_node).value;
+							var type = ((BinaryVDF.StringNode) type_node).value;
+
+							if(type != null && type.down() == "game" && name != null && name.down() == game_name.down())
+							{
+								return app.key;
+							}
+						}
+					}
+				}
+			}
+
+			return null;
+		}
+
 		public static void install_app(string appid)
 		{
 			Utils.open_uri(@"steam://install/$(appid)");

--- a/src/meson.build
+++ b/src/meson.build
@@ -85,6 +85,7 @@ sources = [
 	'data/providers/Provider.vala',
 	'data/providers/ImagesProvider.vala',
 	'data/providers/DataProvider.vala',
+	'data/providers/images/Steam.vala',
 	'data/providers/images/SteamGridDB.vala',
 	'data/providers/images/JinxSGVI.vala',
 	'data/providers/data/IGDB.vala',

--- a/src/settings/Providers.vala
+++ b/src/settings/Providers.vala
@@ -85,24 +85,10 @@ namespace GameHub.Settings.Providers
 		public class Steam: SettingsSchema
 		{
 			public bool enabled { get; set; }
-			public string api_key { get; set; }
 
 			public Steam()
 			{
 				base(ProjectConfig.PROJECT_NAME + ".providers.images.steam");
-			}
-
-			protected override void verify(string key)
-			{
-				switch(key)
-				{
-					case "api-key":
-						if(api_key.length != 32)
-						{
-							schema.reset("api-key");
-						}
-						break;
-				}
 			}
 
 			private static Steam? _instance;

--- a/src/settings/Providers.vala
+++ b/src/settings/Providers.vala
@@ -81,6 +81,43 @@ namespace GameHub.Settings.Providers
 				}
 			}
 		}
+
+		public class Steam: SettingsSchema
+		{
+			public bool enabled { get; set; }
+			public string api_key { get; set; }
+
+			public Steam()
+			{
+				base(ProjectConfig.PROJECT_NAME + ".providers.images.steam");
+			}
+
+			protected override void verify(string key)
+			{
+				switch(key)
+				{
+					case "api-key":
+						if(api_key.length != 32)
+						{
+							schema.reset("api-key");
+						}
+						break;
+				}
+			}
+
+			private static Steam? _instance;
+			public static unowned Steam instance
+			{
+				get
+				{
+					if(_instance == null)
+					{
+						_instance = new Steam();
+					}
+					return _instance;
+				}
+			}
+		}
 	}
 
 	namespace Data

--- a/src/utils/FSUtils.vala
+++ b/src/utils/FSUtils.vala
@@ -76,6 +76,8 @@ namespace GameHub.Utils
 				public const string WineWrap = FSUtils.Paths.Cache.Compat + "/winewrap";
 
 				public const string Sources = FSUtils.Paths.Cache.Home + "/sources";
+
+				public const string Providers = FSUtils.Paths.Cache.Home + "/providers";
 			}
 
 			public class LocalData

--- a/src/utils/FSUtils.vala
+++ b/src/utils/FSUtils.vala
@@ -76,8 +76,6 @@ namespace GameHub.Utils
 				public const string WineWrap = FSUtils.Paths.Cache.Compat + "/winewrap";
 
 				public const string Sources = FSUtils.Paths.Cache.Home + "/sources";
-
-				public const string Providers = FSUtils.Paths.Cache.Home + "/providers";
 			}
 
 			public class LocalData


### PR DESCRIPTION
This adds steam as an image provider for all games which makes _official_ game art available for games owned outside of steam.
If the game isn't owned at steam an _exact_ name search will be performed at a list of all available apps.
Steams applist will be cached and only updated once a day.
Since steam only hosts official game art the steam image provider is placed at the front of all found images.

There's still a flaw I couldn't figure out: Sometimes the _other_ image provider don't load any images. When adding debug messages to see whether they are even searching for images they always load the images so I'm unable to debug this error. Maybe you have an idea why they're missing sometimes.