### PR TITLE
Don't create symlink if there's already a blockdevice linked

### DIFF
--- a/src/data/compat/Proton.vala
+++ b/src/data/compat/Proton.vala
@@ -168,15 +168,52 @@ namespace GameHub.Data.Compat
 
 			var dosdevices = prefix.get_child("dosdevices");
 
-			if(dosdevices.get_child("c:").query_exists() && !dosdevices.get_child("d:").query_exists() && !dosdevices.get_child("d::").query_exists())
+			if(dosdevices.get_child("c:").query_exists() && dosdevices.get_path().has_prefix(runnable.install_dir.get_path()))
 			{
-				if(dosdevices.get_path().has_prefix(runnable.install_dir.get_path()))
+				var has_symlink = false;
+				for(var letter = 'd'; letter <= 'y'; letter++)
 				{
-					Utils.run({"ln", "-nsf", "../../../../../", "d:"}).dir(dosdevices.get_path()).run_sync();
+					if(is_symlink_and_correct(dosdevices.get_child(@"$(letter):")))
+					{
+						has_symlink = true;
+						break;
+					}
+				}
+
+				for(var letter = 'd'; has_symlink == false && letter <= 'y'; letter++)
+				{
+					if(!dosdevices.get_child(@"$(letter):").query_exists() && !dosdevices.get_child(@"$(letter)::").query_exists())
+					{
+						Utils.run({"ln", "-nsf", "../../../../../", @"$(letter):"}).dir(dosdevices.get_path()).run_sync();
+						break;
+					}
 				}
 			}
 
 			return prefix;
+		}
+
+		private bool is_symlink_and_correct(File symlink)
+		{
+			if(!symlink.query_exists())
+			{
+				return false;
+			}
+
+			try
+			{
+				var symlink_info = symlink.query_info("*", NONE);
+				if(symlink_info == null || !symlink_info.get_is_symlink() || symlink_info.get_symlink_target() != "../../../../../")
+				{
+					return false;
+				}
+			}
+			catch (Error e)
+			{
+				return false;
+			}
+
+			return true;
 		}
 
 		protected override string[] prepare_env(Runnable runnable, bool parse_opts=true)

--- a/src/data/compat/Proton.vala
+++ b/src/data/compat/Proton.vala
@@ -148,7 +148,7 @@ namespace GameHub.Data.Compat
 			var prefix = FSUtils.mkdir(install_dir.get_path(), @"$(FSUtils.GAMEHUB_DIR)/$(FSUtils.COMPAT_DATA_DIR)/$(id)/pfx");
 			var dosdevices = prefix.get_child("dosdevices");
 
-			if(FSUtils.file(install_dir.get_path(), @"$(FSUtils.GAMEHUB_DIR)/$(binary)_$(arch)").query_exists())
+			if(FSUtils.file(install_dir.get_path(), @"$(FSUtils.GAMEHUB_DIR)/$(id)").query_exists())
 			{
 				Utils.run({"bash", "-c", @"mv -f $(FSUtils.GAMEHUB_DIR)/$(id) $(FSUtils.GAMEHUB_DIR)/$(FSUtils.COMPAT_DATA_DIR)/$(id)"}).dir(install_dir.get_path()).run_sync();
 				FSUtils.rm(dosdevices.get_child("d:").get_path());
@@ -168,7 +168,7 @@ namespace GameHub.Data.Compat
 
 			var dosdevices = prefix.get_child("dosdevices");
 
-			if(dosdevices.get_child("c:").query_exists() && !dosdevices.get_child("d:").query_exists())
+			if(dosdevices.get_child("c:").query_exists() && !dosdevices.get_child("d:").query_exists() && !dosdevices.get_child("d::").query_exists())
 			{
 				if(dosdevices.get_path().has_prefix(runnable.install_dir.get_path()))
 				{

--- a/src/data/compat/Wine.vala
+++ b/src/data/compat/Wine.vala
@@ -202,15 +202,52 @@ namespace GameHub.Data.Compat
 
 			var dosdevices = prefix.get_child("dosdevices");
 
-			if(dosdevices.get_child("c:").query_exists() && !dosdevices.get_child("d:").query_exists() && !dosdevices.get_child("d::").query_exists())
+			if(dosdevices.get_child("c:").query_exists() && dosdevices.get_path().has_prefix(runnable.install_dir.get_path()))
 			{
-				if(dosdevices.get_path().has_prefix(runnable.install_dir.get_path()))
+				var has_symlink = false;
+				for(var letter = 'd'; letter <= 'y'; letter++)
 				{
-					Utils.run({"ln", "-nsf", "../../../../", "d:"}).dir(dosdevices.get_path()).run_sync();
+					if(is_symlink_and_correct(dosdevices.get_child(@"$(letter):")))
+					{
+						has_symlink = true;
+						break;
+					}
+				}
+
+				for(var letter = 'd'; has_symlink == false && letter <= 'y'; letter++)
+				{
+					if(!dosdevices.get_child(@"$(letter):").query_exists() && !dosdevices.get_child(@"$(letter)::").query_exists())
+					{
+						Utils.run({"ln", "-nsf", "../../../../", @"$(letter):"}).dir(dosdevices.get_path()).run_sync();
+						break;
+					}
 				}
 			}
 
 			return prefix;
+		}
+
+		private bool is_symlink_and_correct(File symlink)
+		{
+			if(!symlink.query_exists())
+			{
+				return false;
+			}
+
+			try
+			{
+				var symlink_info = symlink.query_info("*", NONE);
+				if(symlink_info == null || !symlink_info.get_is_symlink() || symlink_info.get_symlink_target() != "../../../../")
+				{
+					return false;
+				}
+			}
+			catch (Error e)
+			{
+				return false;
+			}
+
+			return true;
 		}
 
 		public override File get_install_root(Runnable runnable)

--- a/src/data/compat/Wine.vala
+++ b/src/data/compat/Wine.vala
@@ -202,7 +202,7 @@ namespace GameHub.Data.Compat
 
 			var dosdevices = prefix.get_child("dosdevices");
 
-			if(dosdevices.get_child("c:").query_exists() && !dosdevices.get_child("d:").query_exists())
+			if(dosdevices.get_child("c:").query_exists() && !dosdevices.get_child("d:").query_exists() && !dosdevices.get_child("d::").query_exists())
 			{
 				if(dosdevices.get_path().has_prefix(runnable.install_dir.get_path()))
 				{


### PR DESCRIPTION
I'm unsure why the device `D:` gets created in the first place ~~so this is only a workaround for #359 for now~~.

My guess is that this will create shorter log file lines and quicker access to the install folder inside the wine explorer. So to get this convenience back we need to look for the next non existing letter both with one colon and two colons: `d:`, `d::`

Fix #359 