### PR TITLE
Enhance steam shortcut creation

### DIFF
--- a/src/data/sources/steam/Steam.vala
+++ b/src/data/sources/steam/Steam.vala
@@ -446,9 +446,13 @@ namespace GameHub.Data.Sources.Steam
 
 			var root_node = vdf.read() as BinaryVDF.ListNode;
 
-			if(root_node == null)
+			if(root_node.get("shortcuts") == null)
 			{
 				root_node = new BinaryVDF.ListNode.node("shortcuts");
+			}
+			else
+			{
+				root_node = root_node.get("shortcuts") as BinaryVDF.ListNode;
 			}
 
 			var game_node = new BinaryVDF.ListNode.node(root_node.nodes.size.to_string());

--- a/src/data/sources/steam/Steam.vala
+++ b/src/data/sources/steam/Steam.vala
@@ -476,6 +476,15 @@ namespace GameHub.Data.Sources.Steam
 
 			var tags_node = new BinaryVDF.ListNode.node("tags");
 			tags_node.add_node(new BinaryVDF.StringNode.node("0", "GameHub"));
+
+			foreach(var tag in game.tags)
+			{
+				if(tag.removable)
+				{
+					tags_node.add_node(new BinaryVDF.StringNode.node((game.tags.index_of(tag) + 1).to_string(), tag.name));
+				}
+			}
+
 			game_node.add_node(tags_node);
 
 			root_node.add_node(game_node);

--- a/src/data/sources/steam/Steam.vala
+++ b/src/data/sources/steam/Steam.vala
@@ -19,6 +19,7 @@ along with GameHub.  If not, see <https://www.gnu.org/licenses/>.
 using Gee;
 using GameHub.Data.DB;
 using GameHub.Utils;
+using ZLib.Utility;
 
 namespace GameHub.Data.Sources.Steam
 {
@@ -472,6 +473,19 @@ namespace GameHub.Data.Sources.Steam
 			{
 				var cached = ImageCache.local_file(game.image, @"games/$(game.source.id)/$(game.id)/images/");
 				game_node.add_node(new BinaryVDF.StringNode.node("icon", cached.get_path()));
+			}
+
+			if(game.image_vertical != null)
+			{
+				try
+				{
+					var cached = ImageCache.local_file(game.image_vertical, @"games/$(game.source.id)/$(game.id)/images/");
+					// https://github.com/boppreh/steamgrid/blob/master/games.go#L120
+					uint64 id = crc32(0, (ProjectConfig.PROJECT_NAME + game.name).data) | 0x80000000;
+					var dest = FSUtils.file(get_userdata_dir().get_child("config").get_child("grid").get_path(), id.to_string() + "p.png");
+					cached.copy(dest, NONE);
+				}
+				catch (Error e) {}
 			}
 
 			var tags_node = new BinaryVDF.ListNode.node("tags");

--- a/src/meson.build
+++ b/src/meson.build
@@ -29,6 +29,7 @@ deps = [
 	dependency('sqlite3'),
 	dependency('libxml-2.0'),
 	dependency('gio-unix-2.0'),
+	dependency('zlib'),
 	meson.get_compiler('vala').find_library('posix'),
 	meson.get_compiler('vala').find_library('linux')
 ]


### PR DESCRIPTION
This fixes #319 by correcting the node which the game gets added to.
It also presets the vertical image cover if one is available.

I've also added that all tags are added to the shortcut in hope they'll create the corresponding collections inside steam automatically but this doesn't work yet. Although adding the game inside steam to a collection adds the tag to the shortcut in the file this doesn't work the other way around.