### PR TITLE
Reduce bandwith pressure by using thumbnails if available

### DIFF
--- a/src/data/providers/ImagesProvider.vala
+++ b/src/data/providers/ImagesProvider.vala
@@ -39,11 +39,14 @@ namespace GameHub.Data.Providers
 		{
 			public string  url         { get; protected construct set; }
 			public string? description { get; protected construct set; default = null; }
+			public string? thumb_url   { get; protected construct set; default = null; }
 
-			public Image(string url, string? description=null)
+			public Image(string url, string? description=null, string? thumb_url=null)
 			{
-				Object(url: url, description: description);
+				Object(url: url, description: description, thumb_url: thumb_url);
 			}
+
+			public bool has_thumbnail { get { return thumb_url != null && thumb_url != ""; } }
 		}
 
 		public struct ImageSize

--- a/src/data/providers/images/Steam.vala
+++ b/src/data/providers/images/Steam.vala
@@ -84,7 +84,7 @@ namespace GameHub.Data.Providers.Images
 					case 600:
 						// Enforced since 2019, possibly not available
 						local_result = yield search_local(appid, "p");
-						remote_result = yield search_remote(appid, "library_600x900_2x.jpg");
+						remote_result = yield search_remote(appid, "library_600x900.jpg");
 						break;
 					}
 
@@ -95,7 +95,7 @@ namespace GameHub.Data.Providers.Images
 
 					if(remote_result != null)
 					{
-						result.images.add(new Image(remote_result, "Remote download"));
+						result.images.add(new Image(yield search_remote(appid, "library_600x900_2x.jpg", false), "Remote download", remote_result));
 					}
 
 					if(result.images.size > 0)

--- a/src/data/providers/images/SteamGridDB.vala
+++ b/src/data/providers/images/SteamGridDB.vala
@@ -204,6 +204,7 @@ namespace GameHub.Data.Providers.Images
 				style = Style.from_string(raw_style);
 				author = obj.has_member("author") ? obj.get_object_member("author").get_string_member("name") : null;
 				score = obj.has_member("score") ? (int) obj.get_int_member("score") : 0;
+				thumb_url = obj.has_member("thumb") ? obj.get_string_member("thumb") : null;
 
 				description = """<span weight="600">%s</span>: %s""".printf(C_("imagesource_steamgriddb_image_property", "Style"), style == null ? raw_style : style.name()) + "\n"
 				            + """<span weight="600">%s</span>: %d""".printf(C_("imagesource_steamgriddb_image_property", "Score"), score);

--- a/src/ui/widgets/ImagesDownloadPopover.vala
+++ b/src/ui/widgets/ImagesDownloadPopover.vala
@@ -246,7 +246,7 @@ namespace GameHub.UI.Widgets
 				card.tooltip_markup = image.description;
 
 				var img = new AutoSizeImage();
-				img.load(image.url, null, @"games/$(game.source.id)/$(game.id)/images/providers/$(provider.id)/");
+				img.load(image.has_thumbnail ? image.thumb_url : image.url, null, @"games/$(game.source.id)/$(game.id)/images/providers/$(provider.id)/");
 
 				card.add(img);
 


### PR DESCRIPTION
For previews use:
* thumbs from steamgriddb (see below)
* `library_600x900.jpg` for steam

Thumbnails from steamgriddb are scaled up too much in the previews but I was unable to reduce the preview size.
Relevant part should be the following lines by decreasing `var max` but I wasn't successful with that.
https://github.com/Lucki/GameHub/blob/faeae90a57eb3d194a7721c4a20717f002bad4d5/src/ui/widgets/ImagesDownloadPopover.vala#L255-261