### PR TITLE
Propagate backend errors to the frontend and display them using lousy UX

### DIFF
--- a/src/app.vala
+++ b/src/app.vala
@@ -339,7 +339,7 @@ namespace GameHub
 				};
 
 				info("Restarting with GDB");
-				Utils.run(exec_cmd).dir(Environment.get_current_dir()).run_sync();
+				Utils.run(exec_cmd).dir(Environment.get_current_dir()).run_sync_nofail();
 				exit_status = 0;
 				return true;
 			}

--- a/src/app.vala
+++ b/src/app.vala
@@ -534,13 +534,47 @@ namespace GameHub
 				{
 					var loop = new MainLoop();
 					game.update_game_info.begin((obj, res) => {
-						game.update_game_info.end(res);
+						try
+						{
+							game.update_game_info.end(res);
+						}
+						catch(Utils.RunError error)
+						{
+							Utils.RunError.prefix(ref error, _("Error while updating game information: "));
+							
+							GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+								null, error, Log.METHOD,
+								_("Launching game “%s” failed").printf(game.name),
+								(result_id) => {
+									loop.quit();
+								}
+							);
+							return;
+						}
+						
 						switch(action.name)
 						{
 							case ACTION_GAME_RUN:
 								info("Starting `%s`", game.name);
 								game.run_or_install.begin(opt_show_compat, (obj, res) => {
-									game.run_or_install.end(res);
+									try
+									{
+										game.run_or_install.end(res);
+									}
+									catch(Utils.RunError error)
+									{
+										Utils.RunError.prefix(ref error, _("Error while launching: "));
+										
+										GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+											null, error, Log.METHOD,
+											_("Launching game “%s” failed").printf(game.name),
+											(result_id) => {
+												loop.quit();
+											}
+										);
+										return;
+									}
+									
 									info("`%s` finished", game.name);
 									loop.quit();
 								});

--- a/src/data/Emulator.vala
+++ b/src/data/Emulator.vala
@@ -169,7 +169,7 @@ namespace GameHub.Data
 			return result_args;
 		}
 
-		public override async void run()
+		public override async void run() throws Utils.RunError
 		{
 			if(can_be_launched(true) && executable.query_exists())
 			{
@@ -184,7 +184,7 @@ namespace GameHub.Data
 			}
 		}
 
-		public async void run_game(Game? game, bool launch_in_game_dir=false)
+		public async void run_game(Game? game, bool launch_in_game_dir=false) throws Utils.RunError
 		{
 			if(use_compat)
 			{

--- a/src/data/GameSource.vala
+++ b/src/data/GameSource.vala
@@ -38,9 +38,9 @@ namespace GameHub.Data
 
 		public abstract bool is_installed(bool refresh=false);
 
-		public abstract async bool install();
+		public abstract async bool install() throws Utils.RunError;
 
-		public abstract async bool authenticate();
+		public abstract async bool authenticate() throws Utils.RunError;
 		public abstract bool is_authenticated();
 		public abstract bool can_authenticate_automatically();
 

--- a/src/data/compat/CustomEmulator.vala
+++ b/src/data/compat/CustomEmulator.vala
@@ -70,15 +70,20 @@ namespace GameHub.Data.Compat
 		public override bool can_run(Runnable runnable)
 		{
 			update_emulators();
-			return installed && runnable is Game && emulator_names.size > 0;
+			return runnable is Game && emulator_names.size > 0;
 		}
 
-		public override async void run(Runnable runnable)
+		public override async void run(Runnable runnable) throws Utils.RunError
 		{
-			if(!can_run(runnable)) return;
+			if(!can_run(runnable))
+			{
+				throw new Utils.RunError.FAILED(
+					_("No custom emulators were set up")
+				);
+			}
 
 			var emu = Tables.Emulators.by_name(emu_option.value);
-			if(emu == null) return;
+			if(emu == null) return;  //XXX: Does this actually happen?
 
 			yield emu.run_game(runnable as Game, game_dir_option.enabled);
 		}

--- a/src/data/compat/RetroArch.vala
+++ b/src/data/compat/RetroArch.vala
@@ -73,7 +73,7 @@ namespace GameHub.Data.Compat
 			try
 			{
 				FileInfo? finfo = null;
-				var enumerator = dir.enumerate_children("standard::*", FileQueryInfoFlags.NOFOLLOW_SYMLINKS);
+				var enumerator = dir.enumerate_children("standard::name", FileQueryInfoFlags.NOFOLLOW_SYMLINKS);
 				while((finfo = enumerator.next_file()) != null)
 				{
 					var fname = finfo.get_name();
@@ -99,11 +99,18 @@ namespace GameHub.Data.Compat
 			return installed && runnable is Game && has_cores;
 		}
 
-		public override async void run(Runnable runnable)
+		public override async void run(Runnable runnable) throws Utils.RunError
 		{
-			if(!can_run(runnable)) return;
+			this.ensure_installed();
+			if(!can_run(runnable))
+			{
+				throw new Utils.RunError.COMMAND_NOT_FOUND(
+					_("RetroArch has no core, please check the logs")
+				);
+			}
+			
 			var core = core_option.value;
-			if(core == null) return;
+			if(core == null) return;  //XXX: When does this happen?
 
 			if(!core.has_prefix("/"))
 			{

--- a/src/data/compat/ScummVM.vala
+++ b/src/data/compat/ScummVM.vala
@@ -47,7 +47,7 @@ namespace GameHub.Data.Compat
 		{
 			if(dir != null && dir.query_exists())
 			{
-				var output = Utils.run({executable.get_path(), "--detect"}).dir(dir.get_path()).log(false).run_sync(true).output;
+				var output = Utils.run({executable.get_path(), "--detect"}).dir(dir.get_path()).log(false).run_sync_nofail(true).output;
 				return !(SCUMMVM_NO_GAMES_WARNING in output);
 			}
 			return false;
@@ -59,9 +59,16 @@ namespace GameHub.Data.Compat
 				&& (scummvm_detect(runnable.install_dir) || scummvm_detect(runnable.install_dir.get_child("data")));
 		}
 
-		public override async void run(Runnable runnable)
+		public override async void run(Runnable runnable) throws Utils.RunError
 		{
-			if(!can_run(runnable)) return;
+			this.ensure_installed();
+			if(!can_run(runnable))
+			{
+				throw new Utils.RunError.INVALID_ARGUMENT(
+					_("Directory “%s” does not appear to contain any ScummVM compatible game files"),
+					runnable.install_dir.get_path()
+				);
+			}
 
 			var dir = runnable.install_dir;
 			var data_dir = runnable.install_dir.get_child("data");

--- a/src/data/providers/data/IGDB.vala
+++ b/src/data/providers/data/IGDB.vala
@@ -458,7 +458,19 @@ namespace GameHub.Data.Providers.Data
 				link.tooltip_text = API_KEY_PAGE;
 
 				link.clicked.connect(() => {
-					Utils.open_uri(API_KEY_PAGE);
+					try
+					{
+						Utils.open_uri(API_KEY_PAGE);
+					}
+					catch(Error e)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						(new Gtk.MessageDialog(
+							grid.get_toplevel() as Gtk.Window,
+							Gtk.DialogFlags.MODAL, Gtk.MessageType.ERROR, Gtk.ButtonsType.OK,
+							"%s\n\n%s", _("Opening IGDB API key page failed"), e.message
+						)).show();
+					}
 				});
 
 				entry_wrapper.add(entry);

--- a/src/data/providers/images/SteamGridDB.vala
+++ b/src/data/providers/images/SteamGridDB.vala
@@ -178,7 +178,19 @@ namespace GameHub.Data.Providers.Images
 				link.tooltip_text = API_KEY_PAGE;
 
 				link.clicked.connect(() => {
-					Utils.open_uri(API_KEY_PAGE);
+					try
+					{
+						Utils.open_uri(API_KEY_PAGE);
+					}
+					catch(Error e)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						(new Gtk.MessageDialog(
+							grid.get_toplevel() as Gtk.Window,
+							Gtk.DialogFlags.MODAL, Gtk.MessageType.ERROR, Gtk.ButtonsType.OK,
+							"%s\n\n%s", _("Opening SteamGrid API key page failed"), e.message
+						)).show();
+					}
 				});
 
 				entry_wrapper.add(entry);

--- a/src/data/sources/humble/HumbleGame.vala
+++ b/src/data/sources/humble/HumbleGame.vala
@@ -190,7 +190,7 @@ namespace GameHub.Data.Sources.Humble
 			update_version();
 		}
 
-		public override async void update_game_info()
+		public override async void update_game_info() throws Utils.RunError
 		{
 			if(game_info_updating) return;
 			game_info_updating = true;
@@ -279,7 +279,7 @@ namespace GameHub.Data.Sources.Humble
 			game_info_updating = false;
 		}
 
-		private async void update_installers()
+		private async void update_installers() throws Utils.RunError
 		{
 			if(installers.size > 0) return;
 
@@ -395,7 +395,7 @@ namespace GameHub.Data.Sources.Humble
 			return refresh;
 		}
 
-		public override async void install(Runnable.Installer.InstallMode install_mode=Runnable.Installer.InstallMode.INTERACTIVE)
+		public override async void install(Runnable.Installer.InstallMode install_mode=Runnable.Installer.InstallMode.INTERACTIVE) throws Utils.RunError
 		{
 			yield update_installers();
 			if(installers.size < 1) return;
@@ -403,7 +403,7 @@ namespace GameHub.Data.Sources.Humble
 			yield;
 		}
 
-		public override async void uninstall()
+		public override async void uninstall() throws Utils.RunError
 		{
 			if(install_dir != null && install_dir.query_exists())
 			{

--- a/src/data/sources/itch/Itch.vala
+++ b/src/data/sources/itch/Itch.vala
@@ -252,7 +252,18 @@ namespace GameHub.Data.Sources.Itch
 				}
 				if(file != null)
 				{
-					Utils.open_uri(file.get_uri());
+					try
+					{
+						Utils.open_uri(file.get_uri());
+					}
+					catch(Utils.RunError e)
+					{
+						//XXX: Should this be propagated to the UI?
+						warning(
+							"[Sources.Itch] Error while processing %s action: %s-(%s:%d)",
+							method, e.message, e.domain.to_string(), e.code
+						);
+					}
 				}
 				responder.respond();
 			});

--- a/src/data/sources/itch/ItchGame.vala
+++ b/src/data/sources/itch/ItchGame.vala
@@ -119,7 +119,7 @@ namespace GameHub.Data.Sources.Itch
 			update_status();
 		}
 
-		public override async void update_game_info()
+		public override async void update_game_info() throws Utils.RunError
 		{
 			update_status();
 		}

--- a/src/data/sources/steam/Steam.vala
+++ b/src/data/sources/steam/Steam.vala
@@ -119,17 +119,20 @@ namespace GameHub.Data.Sources.Steam
 			return find_app_install_dir(app, null);
 		}
 
-		public override async bool install()
+		public override async bool install() throws Utils.RunError
 		{
 			var distro = Utils.get_distro().down();
+			//XXX: Why is this list so short?
 			if("elementary" in distro || "pop!_os" in distro)
 			{
 				Utils.open_uri("appstream://steam.desktop");
 			}
-			return true;
+			throw new Utils.RunError.NOT_SUPPORTED(
+				_("Installing Steam is not supported on this platform")
+			);
 		}
 
-		public override async bool authenticate()
+		public override async bool authenticate() throws Utils.RunError
 		{
 			Settings.Auth.Steam.instance.authenticated = true;
 
@@ -358,12 +361,12 @@ namespace GameHub.Data.Sources.Steam
 			return null;
 		}
 
-		public static void install_app(string appid)
+		public static void install_app(string appid) throws Utils.RunError
 		{
 			Utils.open_uri(@"steam://install/$(appid)");
 		}
 
-		public static void install_multiple_apps(string[] appids)
+		public static void install_multiple_apps(string[] appids) throws Utils.RunError
 		{
 			if(instance.packageinfo == null) return;
 			var packages = "";

--- a/src/data/sources/steam/SteamGame.vala
+++ b/src/data/sources/steam/SteamGame.vala
@@ -119,7 +119,7 @@ namespace GameHub.Data.Sources.Steam
 			update_status();
 		}
 
-		public override async void update_game_info()
+		public override async void update_game_info() throws Utils.RunError
 		{
 			if(game_info_updating) return;
 			game_info_updating = true;
@@ -259,13 +259,13 @@ namespace GameHub.Data.Sources.Steam
 			status = new Game.Status(state, this);
 		}
 
-		public override async void install(Runnable.Installer.InstallMode install_mode=Runnable.Installer.InstallMode.INTERACTIVE)
+		public override async void install(Runnable.Installer.InstallMode install_mode=Runnable.Installer.InstallMode.INTERACTIVE) throws Utils.RunError
 		{
 			Steam.install_app(id);
 			update_status();
 		}
 
-		public override async void run()
+		public override async void run() throws Utils.RunError
 		{
 			if(!can_be_launched(true)) return;
 			last_launch = get_real_time() / 1000000;
@@ -274,12 +274,12 @@ namespace GameHub.Data.Sources.Steam
 			update_status();
 		}
 
-		public override async void run_with_compat(bool is_opened_from_menu=false)
+		public override async void run_with_compat(bool is_opened_from_menu=false) throws Utils.RunError
 		{
 			yield run();
 		}
 
-		public override async void uninstall()
+		public override async void uninstall() throws Utils.RunError
 		{
 			Utils.open_uri(@"steam://uninstall/$(id)");
 			update_status();

--- a/src/data/sources/user/UserGame.vala
+++ b/src/data/sources/user/UserGame.vala
@@ -127,7 +127,7 @@ namespace GameHub.Data.Sources.User
 			update_status();
 		}
 
-		public override async void update_game_info()
+		public override async void update_game_info() throws Utils.RunError
 		{
 			yield mount_overlays();
 			update_status();
@@ -141,7 +141,7 @@ namespace GameHub.Data.Sources.User
 			save();
 		}
 
-		public override async void install(Runnable.Installer.InstallMode install_mode=Runnable.Installer.InstallMode.INTERACTIVE)
+		public override async void install(Runnable.Installer.InstallMode install_mode=Runnable.Installer.InstallMode.INTERACTIVE) throws Utils.RunError
 		{
 			yield update_game_info();
 			if(installer == null) return;
@@ -151,7 +151,7 @@ namespace GameHub.Data.Sources.User
 			yield;
 		}
 
-		public override async void uninstall()
+		public override async void uninstall() throws Utils.RunError
 		{
 			yield umount_overlays();
 			remove();

--- a/src/meson.build
+++ b/src/meson.build
@@ -168,6 +168,7 @@ sources = [
 	'ui/widgets/SettingsSidebar.vala',
 	'ui/widgets/TweaksList.vala',
 
+	'utils/RunError.vala',
 	'utils/Utils.vala',
 	'utils/ImageCache.vala',
 	'utils/FSUtils.vala',

--- a/src/meson.build
+++ b/src/meson.build
@@ -121,6 +121,7 @@ sources = [
 	'ui/dialogs/CorruptedInstallerDialog.vala',
 	'ui/dialogs/ImportEmulatedGamesDialog.vala',
 	'ui/dialogs/GameTweaksDialog.vala',
+	'ui/dialogs/QuickErrorDialog.vala',
 
 	'ui/views/BaseView.vala',
 	'ui/views/WelcomeView.vala',

--- a/src/ui/dialogs/CompatRunDialog.vala
+++ b/src/ui/dialogs/CompatRunDialog.vala
@@ -132,7 +132,20 @@ namespace GameHub.UI.Dialogs
 				emulated_game.is_running = true;
 				emulated_game.update_status();
 				compat_tool_picker.selected.run_emulator.begin(game as Emulator, emulated_game, launch_in_game_dir, (obj, res) => {
-					compat_tool_picker.selected.run_emulator.end(res);
+					try
+					{
+						compat_tool_picker.selected.run_emulator.end(res);
+					}
+					catch(Utils.RunError e)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						QuickErrorDialog.display_and_log.begin(
+							this, e, Log.METHOD,
+							_("Launching game “%s” in emulator “%s” failed").printf(
+								emulated_game.name, game.name
+							)
+						);
+					}
 					Timeout.add_seconds(1, () => {
 						Runnable.IsLaunched = game.is_running = emulated_game.is_running = false;
 						emulated_game.update_status();
@@ -147,7 +160,20 @@ namespace GameHub.UI.Dialogs
 				(game as Game).last_launch = get_real_time() / 1000000;
 				game.save();
 				compat_tool_picker.selected.run.begin(game, (obj, res) => {
-					compat_tool_picker.selected.run.end(res);
+					try
+					{
+						compat_tool_picker.selected.run.end(res);
+					}
+					catch(Utils.RunError e)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						QuickErrorDialog.display_and_log.begin(
+							this, e, Log.METHOD,
+							_("Launching game “%s” in compatiblity tool “%s” failed").printf(
+								game.name, compat_tool_picker.selected.name
+							)
+						);
+					}
 					Timeout.add_seconds(1, () => {
 						Runnable.IsLaunched = game.is_running = false;
 						game.update_status();

--- a/src/ui/dialogs/GameFSOverlaysDialog.vala
+++ b/src/ui/dialogs/GameFSOverlaysDialog.vala
@@ -287,7 +287,20 @@ namespace GameHub.UI.Dialogs
 				child = grid;
 
 				open.clicked.connect(() => {
-					Utils.open_uri(overlay.directory.get_uri());
+					try
+					{
+						Utils.open_uri(overlay.directory.get_uri());
+					}
+					catch(Utils.RunError error)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+							this, error, Log.METHOD,
+							_("Opening overlay directory “%s” of overlay “%s” failed").printf(
+								overlay.directory.get_path(), overlay.name
+							)
+						);
+					}
 				});
 
 				remove.clicked.connect(() => {

--- a/src/ui/dialogs/ImportEmulatedGamesDialog.vala
+++ b/src/ui/dialogs/ImportEmulatedGamesDialog.vala
@@ -266,7 +266,7 @@ namespace GameHub.UI.Dialogs
 							sp = sp.substring(sp.index_of_nth_char(2));
 						}
 
-						var files_list = Utils.run({"find", root.get_path(), "-path", "*/" + sp, "-type", "f"}).log(false).run_sync(true).output;
+						var files_list = Utils.run({"find", root.get_path(), "-path", "*/" + sp, "-type", "f"}).log(false).run_sync_nofail(true).output;
 						var files = files_list.split("\n");
 
 						foreach(var file_path in files)
@@ -383,7 +383,7 @@ namespace GameHub.UI.Dialogs
 							ext = ext.strip();
 							if(ext in ignored_extensions) continue;
 
-							var files_list = Utils.run({"find", root.get_path(), "-path", "*/*." + ext, "-type", "f"}).log(false).run_sync(true).output;
+							var files_list = Utils.run({"find", root.get_path(), "-path", "*/*." + ext, "-type", "f"}).log(false).run_sync_nofail(true).output;
 							var files = files_list.split("\n");
 
 							foreach(var file_path in files)
@@ -629,7 +629,7 @@ namespace GameHub.UI.Dialogs
 
 						sp = sp.replace("${basename}", basename).replace("$basename", basename);
 
-						var files_list = Utils.run({"find", directory.get_path(), "-path", "*/" + sp}).log(false).run_sync(true).output;
+						var files_list = Utils.run({"find", directory.get_path(), "-path", "*/" + sp}).log(false).run_sync_nofail(true).output;
 						var files = files_list.split("\n");
 
 						foreach(var file_path in files)

--- a/src/ui/dialogs/InstallDialog.vala
+++ b/src/ui/dialogs/InstallDialog.vala
@@ -332,9 +332,21 @@ namespace GameHub.UI.Dialogs
 					yield dl_installer.download(runnable);
 				}
 			}
+
 			if(response_id == ResponseType.ACCEPT)
 			{
-				yield installer.install(runnable, tool);
+				try
+				{
+					yield installer.install(runnable, tool);
+				}
+				catch(Utils.RunError error)
+				{
+					//FIXME [DEV-ART]: Replace this with inline error display?
+					yield QuickErrorDialog.display_and_log(
+						this, error, Log.METHOD,
+						_("Installing game “%s” failed").printf(runnable.name)
+					);
+				}
 			}
 			if(callback != null) callback();
 		}

--- a/src/ui/dialogs/QuickErrorDialog.vala
+++ b/src/ui/dialogs/QuickErrorDialog.vala
@@ -1,0 +1,88 @@
+/*
+This file is part of GameHub.
+Copyright (C) 2018-2019 Anatoliy Kashkin
+
+GameHub is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+GameHub is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GameHub.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+namespace GameHub.UI.Dialogs
+{
+	public class QuickErrorDialog : Gtk.MessageDialog
+	{
+		[PrintfFormat]
+		public QuickErrorDialog(Gtk.Widget? parent, Utils.RunError error, string? text_fmt, ...)
+		{
+			// Set properties on dialog like `Gtk.MessageDialog.new` does:
+			// https://gitlab.gnome.org/GNOME/gtk/-/blob/8cb50ac6e9c6a78f337e4ad2bb61aa0558844904/gtk/gtkmessagedialog.c#L492-552
+			Object(
+				use_header_bar: 0,
+				message_type: Gtk.MessageType.ERROR,
+				buttons: Gtk.ButtonsType.OK
+			);
+			this.set_transient_for(parent.get_toplevel() as Gtk.Window);
+			
+			// Generate primary error text
+			if(text_fmt != null)
+			{
+				va_list va_list = va_list();
+				this.text = text_fmt.vprintf(va_list);
+			}
+			
+			// Generate secondary error text from exception
+			if(error.message.last_index_of_char(')', error.message.length - 1) > -1)
+			{
+				this.format_secondary_text("%s-(%s:%d)", error.message, error.domain.to_string(), error.code);
+			}
+			else
+			{
+				this.format_secondary_text("%s (%s:%d)", error.message, error.domain.to_string(), error.code);
+			}
+		}
+		
+		
+		public static async int display_and_log(Gtk.Widget? parent, Utils.RunError error, string caller_name, string text)
+		{
+			// Create dialog object
+			QuickErrorDialog dialog = new QuickErrorDialog(parent, error, null);
+			
+			// Format and set primary text
+			dialog.text = text;
+			
+			// Log error message
+			warning("[%s] %s – %s", caller_name, text, dialog.secondary_text);
+			
+			// Display error message
+			dialog.show();
+			
+			// Delay response until dialog is closed
+			int response_id = Gtk.ResponseType.NONE;
+			dialog.response.connect((response) => {
+				response_id = response;
+				display_and_log.callback();
+			});
+			dialog.destroy.connect(() => {
+				if(response_id == Gtk.ResponseType.NONE)
+				{
+					display_and_log.callback();
+				}
+			});
+			yield;
+			
+			// Clean up and return selected ID
+			dialog.destroy();
+			return response_id;
+		}
+	}
+}

--- a/src/ui/dialogs/SettingsDialog/pages/About.vala
+++ b/src/ui/dialogs/SettingsDialog/pages/About.vala
@@ -159,7 +159,18 @@ namespace GameHub.UI.Dialogs.SettingsDialog.Pages
 			button.tooltip_text = url;
 
 			button.clicked.connect(() => {
-				Utils.open_uri(url);
+				try
+				{
+					Utils.open_uri(url);
+				}
+				catch(Utils.RunError error)
+				{
+					//FIXME [DEV-ART]: Replace this with inline error display?
+					GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+						this, error, Log.METHOD,
+						_("Opening website “%s” failed").printf(url)
+					);
+				}
 			});
 
 			(parent ?? links_view).add(button);

--- a/src/ui/dialogs/SettingsDialog/pages/emulators/Emulators.vala
+++ b/src/ui/dialogs/SettingsDialog/pages/emulators/Emulators.vala
@@ -422,7 +422,19 @@ namespace GameHub.UI.Dialogs.SettingsDialog.Pages.Emulators
 
 					emulator.executable = null;
 					emulator.install.begin(Runnable.Installer.InstallMode.INTERACTIVE, (obj, res) => {
-						emulator.install.end(res);
+						try
+						{
+							emulator.install.end(res);
+						}
+						catch(Utils.RunError error)
+						{
+							//FIXME [DEV-ART]: Replace this with inline error display?
+							GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+								this, error, Log.METHOD,
+								//TODO: Is this accurate?
+								_("Installing emulator “%s” failed").printf(emulator.name)
+							);
+						}
 						sensitive = true;
 						mode.selected = 0;
 						executable.select_file(emulator.executable);

--- a/src/ui/dialogs/SettingsDialog/pages/general/Tweaks.vala
+++ b/src/ui/dialogs/SettingsDialog/pages/general/Tweaks.vala
@@ -97,7 +97,20 @@ namespace GameHub.UI.Dialogs.SettingsDialog.Pages.General
 
 			dirs_btn.add(dirs_btn_label);
 
-			dirs_btn.clicked.connect(() => { Utils.open_uri(last_dir.get_uri()); });
+			dirs_btn.clicked.connect(() => {
+				try
+				{
+					Utils.open_uri(last_dir.get_uri());
+				}
+				catch(Utils.RunError error)
+				{
+					//FIXME [DEV-ART]: Replace this with inline error display?
+					GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+						this, error, Log.METHOD,
+						_("Opening directory “%s” failed").printf(last_dir.get_path())
+					);
+				}
+			});
 
 			add_widget(dirs_btn);
 		}

--- a/src/ui/dialogs/SettingsDialog/pages/providers/Providers.vala
+++ b/src/ui/dialogs/SettingsDialog/pages/providers/Providers.vala
@@ -181,7 +181,20 @@ namespace GameHub.UI.Dialogs.SettingsDialog.Pages.Providers
 				});
 
 				open.clicked.connect(() => {
-					Utils.open_uri(provider.url);
+					try
+					{
+						Utils.open_uri(provider.url);
+					}
+					catch(Utils.RunError error)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+							this, error, Log.METHOD,
+							_("Opening provider website “%s” of provider “%s” failed").printf(
+								provider.url, provider.name
+							)
+						);
+					}
 				});
 			}
 		}

--- a/src/ui/dialogs/SettingsDialog/pages/sources/Steam.vala
+++ b/src/ui/dialogs/SettingsDialog/pages/sources/Steam.vala
@@ -201,7 +201,19 @@ namespace GameHub.UI.Dialogs.SettingsDialog.Pages.Sources
 					install.clicked.connect(() => {
 						install.sensitive = false;
 						page.request_restart();
-						proton.install_app();
+						
+						try
+						{
+							proton.install_app();
+						}
+						catch(Utils.RunError error)
+						{
+							//FIXME [DEV-ART]: Replace this with inline error display?
+							GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+								this, error, Log.METHOD,
+								_("Installing Proton failed")
+							);
+						}
 					});
 				}
 

--- a/src/ui/views/GameDetailsView/GameDetailsPage.vala
+++ b/src/ui/views/GameDetailsView/GameDetailsPage.vala
@@ -347,9 +347,22 @@ namespace GameHub.UI.Views.GameDetailsView
 
 			if(game == null) return;
 
-			yield game.update_game_info();
-
-			is_updated = true;
+			try
+			{
+				yield game.update_game_info();
+				
+				is_updated = true;
+			}
+			catch(Utils.RunError error)
+			{
+				is_updated = false;
+				
+				//FIXME [DEV-ART]: Replace this with inline error display?
+				yield GameHub.UI.Dialogs.QuickErrorDialog.display_and_log(
+					this, error, Log.METHOD,
+					_("Updating game information failed")
+				);
+			}
 
 			title.label = game.name;
 			src_icon.icon_name = game.source.icon;
@@ -436,7 +449,20 @@ namespace GameHub.UI.Views.GameDetailsView
 		{
 			if(_game != null && game.status.state == Game.State.INSTALLED && game.install_dir != null && game.install_dir.query_exists())
 			{
-				Utils.open_uri(game.install_dir.get_uri());
+				try
+				{
+					Utils.open_uri(game.install_dir.get_uri());
+				}
+				catch(Utils.RunError error)
+				{
+					//FIXME [DEV-ART]: Replace this with inline error display?
+					GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+						this, error, Log.METHOD,
+						_("Opening game directory “%s” of game “%s” failed").printf(
+							game.install_dir.get_path(), game.name
+						)
+					);
+				}
 			}
 		}
 
@@ -444,7 +470,20 @@ namespace GameHub.UI.Views.GameDetailsView
 		{
 			if(_game != null && game.installers_dir != null && game.installers_dir.query_exists())
 			{
-				Utils.open_uri(game.installers_dir.get_uri());
+				try
+				{
+					Utils.open_uri(game.installers_dir.get_uri());
+				}
+				catch(Utils.RunError error)
+				{
+					//FIXME [DEV-ART]: Replace this with inline error display?
+					GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+						this, error, Log.METHOD,
+						_("Opening installer directory “%s” of game “%s” failed").printf(
+							game.installers_dir.get_path(), game.name
+						)
+					);
+				}
 			}
 		}
 
@@ -455,7 +494,20 @@ namespace GameHub.UI.Views.GameDetailsView
 				var gog_game = game as GameHub.Data.Sources.GOG.GOGGame;
 				if(gog_game != null && gog_game.bonus_content_dir != null && gog_game.bonus_content_dir.query_exists())
 				{
-					Utils.open_uri(gog_game.bonus_content_dir.get_uri());
+					try
+					{
+						Utils.open_uri(gog_game.bonus_content_dir.get_uri());
+					}
+					catch(Utils.RunError error)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+							this, error, Log.METHOD,
+							_("Opening bonus content directory “%s” of game “%s” failed").printf(
+								gog_game.bonus_content_dir.get_path(), game.name
+							)
+						);
+					}
 				}
 			}
 		}
@@ -467,7 +519,20 @@ namespace GameHub.UI.Views.GameDetailsView
 				var steam_game = game as GameHub.Data.Sources.Steam.SteamGame;
 				if(steam_game != null && steam_game.screenshots_dir != null && steam_game.screenshots_dir.query_exists())
 				{
-					Utils.open_uri(steam_game.screenshots_dir.get_uri());
+					try
+					{
+						Utils.open_uri(steam_game.screenshots_dir.get_uri());
+					}
+					catch(Utils.RunError error)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+							this, error, Log.METHOD,
+							_("Opening screenshot directory “%s” of game “%s” failed").printf(
+								steam_game.screenshots_dir.get_path(), game.name
+							)
+						);
+					}
 				}
 			}
 		}
@@ -476,7 +541,20 @@ namespace GameHub.UI.Views.GameDetailsView
 		{
 			if(_game != null && game.store_page != null)
 			{
-				Utils.open_uri(game.store_page);
+				try
+				{
+					Utils.open_uri(game.store_page);
+				}
+				catch(Utils.RunError error)
+				{
+					//FIXME [DEV-ART]: Replace this with inline error display?
+					GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+						this, error, Log.METHOD,
+						_("Opening game store page “%s” of game “%s” failed").printf(
+							game.store_page, game.name
+						)
+					);
+				}
 			}
 		}
 
@@ -484,7 +562,20 @@ namespace GameHub.UI.Views.GameDetailsView
 		{
 			if(_game != null && game.status.state == Game.State.INSTALLED)
 			{
-				game.run.begin();
+				game.run.begin((obj, res) => {
+					try
+					{
+						game.run.end(res);
+					}
+					catch(Utils.RunError error)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+							this, error, Log.METHOD,
+							_("Launching game “%s” failed").printf(game.name)
+						);
+					}
+				});
 			}
 		}
 
@@ -492,7 +583,20 @@ namespace GameHub.UI.Views.GameDetailsView
 		{
 			if(_game != null && game.status.state == Game.State.INSTALLED)
 			{
-				game.run_with_compat.begin(false);
+				game.run_with_compat.begin(false, (obj, res) => {
+					try
+					{
+						game.run_with_compat.end(res);
+					}
+					catch(Utils.RunError error)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+							this, error, Log.METHOD,
+							_("Launching game “%s” failed").printf(game.name)
+						);
+					}
+				});
 			}
 		}
 
@@ -500,7 +604,20 @@ namespace GameHub.UI.Views.GameDetailsView
 		{
 			if(_game != null && game.status.state == Game.State.INSTALLED)
 			{
-				game.uninstall.begin();
+				game.uninstall.begin((obj, res) => {
+					try
+					{
+						game.uninstall.end(res);
+					}
+					catch(Utils.RunError error)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+							this, error, Log.METHOD,
+							_("Uninstalling game “%s” failed").printf(game.name)
+						);
+					}
+				});
 			}
 		}
 

--- a/src/ui/views/GameDetailsView/MultipleGamesDetailsView.vala
+++ b/src/ui/views/GameDetailsView/MultipleGamesDetailsView.vala
@@ -194,7 +194,20 @@ namespace GameHub.UI.Views.GameDetailsView
 				}
 				if(steam_apps.length > 0)
 				{
-					Sources.Steam.Steam.install_multiple_apps(steam_apps);
+					try
+					{
+						Sources.Steam.Steam.install_multiple_apps(steam_apps);
+					}
+					catch(Utils.RunError error)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+							this, error, Log.METHOD,
+							_("Installing Steam apps “%s” failed").printf(
+								string.joinv(_("”, “"), steam_apps)
+							)
+						);
+					}
 				}
 			}
 
@@ -202,7 +215,20 @@ namespace GameHub.UI.Views.GameDetailsView
 			{
 				if(!(game is Sources.Steam.SteamGame))
 				{
-					game.install.begin(Runnable.Installer.InstallMode.AUTOMATIC);
+					game.install.begin(Runnable.Installer.InstallMode.AUTOMATIC, (obj, res) => {
+						try
+						{
+							game.install.end(res);
+						}
+						catch(Utils.RunError error)
+						{
+							//FIXME [DEV-ART]: Replace this with inline error display?
+							GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+								this, error, Log.METHOD,
+								_("Installing game “%s” failed").printf(game.name)
+							);
+						}
+					});
 				}
 			}
 			update();
@@ -248,7 +274,18 @@ namespace GameHub.UI.Views.GameDetailsView
 		{
 			foreach(var game in games)
 			{
-				yield game.uninstall();
+				try
+				{
+					yield game.uninstall();
+				}
+				catch(Utils.RunError error)
+				{
+					//FIXME [DEV-ART]: Replace this with inline error display?
+					GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+						this, error, Log.METHOD,
+						_("Uninstalling game “%s” failed").printf(game.name)
+					);
+				}
 			}
 			update();
 		}

--- a/src/ui/views/GameDetailsView/blocks/GOGDetails.vala
+++ b/src/ui/views/GameDetailsView/blocks/GOGDetails.vala
@@ -56,7 +56,18 @@ namespace GameHub.UI.Views.GameDetailsView.Blocks
 			{
 				link.tooltip_text = game.store_page;
 				link.clicked.connect(() => {
-					Utils.open_uri(game.store_page);
+					try
+					{
+						Utils.open_uri(game.store_page);
+					}
+					catch(Utils.RunError error)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+							this, error, Log.METHOD,
+							_("Opening website “%s” failed").printf(game.store_page)
+						);
+					}
 				});
 			}
 
@@ -316,7 +327,18 @@ namespace GameHub.UI.Views.GameDetailsView.Blocks
 						}
 						else if(bonus.status.state == GOGGame.BonusContent.State.DOWNLOADED)
 						{
-							bonus.open();
+							try
+							{
+								bonus.open();
+							}
+							catch(Utils.RunError error)
+							{
+								//FIXME [DEV-ART]: Replace this with inline error display?
+								GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+									this, error, Log.METHOD,
+									_("Opening bonus content “%s” failed").printf(bonus.text)
+								);
+							}
 						}
 					}
 					return true;

--- a/src/ui/views/GameDetailsView/blocks/IGDBInfo.vala
+++ b/src/ui/views/GameDetailsView/blocks/IGDBInfo.vala
@@ -65,7 +65,18 @@ namespace GameHub.UI.Views.GameDetailsView.Blocks
 			{
 				igdb_link.tooltip_text = result.url;
 				igdb_link.clicked.connect(() => {
-					Utils.open_uri(result.url);
+					try
+					{
+						Utils.open_uri(result.url);
+					}
+					catch(Utils.RunError error)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+							this, error, Log.METHOD,
+							_("Opening website “%s” failed").printf(result.url)
+						);
+					}
 				});
 			}
 			else
@@ -174,7 +185,18 @@ namespace GameHub.UI.Views.GameDetailsView.Blocks
 					}
 					var link = new ActionButton(site.category.icon(), null, desc, false, true);
 					link.clicked.connect(() => {
-						Utils.open_uri(site.url);
+						try
+						{
+							Utils.open_uri(site.url);
+						}
+						catch(Utils.RunError error)
+						{
+							//FIXME [DEV-ART]: Replace this with inline error display?
+							GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+								this, error, Log.METHOD,
+								_("Opening website “%s” failed").printf(site.url)
+							);
+						}
 					});
 					links_box.add(link);
 				}

--- a/src/ui/views/GameDetailsView/blocks/SteamDetails.vala
+++ b/src/ui/views/GameDetailsView/blocks/SteamDetails.vala
@@ -52,7 +52,18 @@ namespace GameHub.UI.Views.GameDetailsView.Blocks
 			{
 				link.tooltip_text = game.store_page;
 				link.clicked.connect(() => {
-					Utils.open_uri(game.store_page);
+					try
+					{
+						Utils.open_uri(game.store_page);
+					}
+					catch(Utils.RunError error)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+							this, error, Log.METHOD,
+							_("Opening website “%s” failed").printf(game.store_page)
+						);
+					}
 				});
 			}
 

--- a/src/ui/views/GamesView/GameContextMenu.vala
+++ b/src/ui/views/GamesView/GameContextMenu.vala
@@ -213,11 +213,25 @@ namespace GameHub.UI.Views.GamesView
 			#endif
 		}
 
+		//XXX: Why are these duplicated from `GameHub.UI.Views.GameDetailsView.GameDetailsPage`?
 		private void open_game_directory()
 		{
 			if(game != null && game.status.state == Game.State.INSTALLED && game.install_dir != null && game.install_dir.query_exists())
 			{
-				Utils.open_uri(game.install_dir.get_uri());
+				try
+				{
+					Utils.open_uri(game.install_dir.get_uri());
+				}
+				catch(Utils.RunError error)
+				{
+					//FIXME [DEV-ART]: Replace this with inline error display?
+					GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+						this, error, Log.METHOD,
+						_("Opening game directory “%s” of game “%s” failed").printf(
+							game.install_dir.get_path(), game.name
+						)
+					);
+				}
 			}
 		}
 
@@ -225,7 +239,20 @@ namespace GameHub.UI.Views.GamesView
 		{
 			if(game != null && game.installers_dir != null && game.installers_dir.query_exists())
 			{
-				Utils.open_uri(game.installers_dir.get_uri());
+				try
+				{
+					Utils.open_uri(game.installers_dir.get_uri());
+				}
+				catch(Utils.RunError error)
+				{
+					//FIXME [DEV-ART]: Replace this with inline error display?
+					GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+						this, error, Log.METHOD,
+						_("Opening installer directory “%s” of game “%s” failed").printf(
+							game.installers_dir.get_path(), game.name
+						)
+					);
+				}
 			}
 		}
 
@@ -236,7 +263,20 @@ namespace GameHub.UI.Views.GamesView
 				var gog_game = game as GameHub.Data.Sources.GOG.GOGGame;
 				if(gog_game != null && gog_game.bonus_content_dir != null && gog_game.bonus_content_dir.query_exists())
 				{
-					Utils.open_uri(gog_game.bonus_content_dir.get_uri());
+					try
+					{
+						Utils.open_uri(gog_game.bonus_content_dir.get_uri());
+					}
+					catch(Utils.RunError error)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+							this, error, Log.METHOD,
+							_("Opening bonus content directory “%s” of game “%s” failed").printf(
+								gog_game.bonus_content_dir.get_path(), game.name
+							)
+						);
+					}
 				}
 			}
 		}
@@ -248,7 +288,20 @@ namespace GameHub.UI.Views.GamesView
 				var steam_game = game as GameHub.Data.Sources.Steam.SteamGame;
 				if(steam_game != null && steam_game.screenshots_dir != null && steam_game.screenshots_dir.query_exists())
 				{
-					Utils.open_uri(steam_game.screenshots_dir.get_uri());
+					try
+					{
+						Utils.open_uri(steam_game.screenshots_dir.get_uri());
+					}
+					catch(Utils.RunError error)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+							this, error, Log.METHOD,
+							_("Opening screenshot directory “%s” of game “%s” failed").printf(
+								steam_game.screenshots_dir.get_path(), game.name
+							)
+						);
+					}
 				}
 			}
 		}

--- a/src/ui/views/GamesView/GamesView.vala
+++ b/src/ui/views/GamesView/GamesView.vala
@@ -639,7 +639,18 @@ namespace GameHub.UI.Views.GamesView
 						switch(r)
 						{
 							case 1:
-								Utils.open_uri("steam://openurl/https://steamcommunity.com/my/edit/settings");
+								try
+								{
+									Utils.open_uri("steam://openurl/https://steamcommunity.com/my/edit/settings");
+								}
+								catch(Utils.RunError error)
+								{
+									//FIXME [DEV-ART]: Replace this with inline error display?
+									GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+										this, error, Log.METHOD,
+										_("Launching Stream Community settings failed")
+									);
+								}
 								break;
 
 							case 2:

--- a/src/ui/views/WelcomeView.vala
+++ b/src/ui/views/WelcomeView.vala
@@ -151,7 +151,18 @@ namespace GameHub.UI.Views
 						{
 							btn.description = _("Authenticating…");
 							welcome.set_item_sensitivity(index, false);
-							yield src.authenticate();
+							try
+							{
+								yield src.authenticate();
+							}
+							catch(Utils.RunError error)
+							{
+								//FIXME [DEV-ART]: Replace this with inline error display?
+								yield GameHub.UI.Dialogs.QuickErrorDialog.display_and_log(
+									this, error, Log.METHOD,
+									_("Authenticating with “%s” failed").printf(src.name)
+								);
+							}
 							is_updating = false;
 							update_entries.begin();
 							return;
@@ -203,7 +214,21 @@ namespace GameHub.UI.Views
 			{
 				if(!src.is_authenticated())
 				{
-					if(!(yield src.authenticate()))
+					bool succeeded = false;
+					try
+					{
+						succeeded = yield src.authenticate();
+					}
+					catch(Utils.RunError error)
+					{
+						//FIXME [DEV-ART]: Replace this with inline error display?
+						yield GameHub.UI.Dialogs.QuickErrorDialog.display_and_log(
+							this, error, Log.METHOD,
+							_("Authenticating with “%s” failed").printf(src.name)
+						);
+					}
+					
+					if(!succeeded)
 					{
 						welcome.set_item_sensitivity(index, true);
 						return;
@@ -213,7 +238,18 @@ namespace GameHub.UI.Views
 			}
 			else
 			{
-				yield src.install();
+				try
+				{
+					yield src.install();
+				}
+				catch(Utils.RunError error)
+				{
+					//FIXME [DEV-ART]: Replace this with inline error display?
+					yield GameHub.UI.Dialogs.QuickErrorDialog.display_and_log(
+						this, error, Log.METHOD,
+						_("Installing “%s” failed").printf(src.name)
+					);
+				}
 				welcome.set_item_sensitivity(index, true);
 			}
 		}

--- a/src/ui/widgets/CompatToolPicker.vala
+++ b/src/ui/widgets/CompatToolPicker.vala
@@ -189,7 +189,9 @@ namespace GameHub.UI.Widgets
 			var btn = new Button.with_label(action.name);
 			btn.tooltip_text = action.description;
 			btn.hexpand = true;
-			btn.clicked.connect(() => action.invoke(runnable));
+			btn.clicked.connect(() => action.invoke.begin(runnable, (obj, res) => {
+				action.invoke.end(res);
+			}));
 			actions.add(btn);
 		}
 

--- a/src/ui/widgets/CompatToolPicker.vala
+++ b/src/ui/widgets/CompatToolPicker.vala
@@ -190,7 +190,18 @@ namespace GameHub.UI.Widgets
 			btn.tooltip_text = action.description;
 			btn.hexpand = true;
 			btn.clicked.connect(() => action.invoke.begin(runnable, (obj, res) => {
-				action.invoke.end(res);
+				try
+				{
+					action.invoke.end(res);
+				}
+				catch(Utils.RunError e)
+				{
+					//FIXME [DEV-ART]: Replace this with inline error display?
+					GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+						this, e, Log.METHOD,
+						_("Launching action “%s” failed").printf(action.name)
+					);
+				}
 			}));
 			actions.add(btn);
 		}

--- a/src/ui/widgets/ImagesDownloadPopover.vala
+++ b/src/ui/widgets/ImagesDownloadPopover.vala
@@ -153,7 +153,18 @@ namespace GameHub.UI.Widgets
 							link.get_style_context().add_class(Gtk.STYLE_CLASS_FLAT);
 							link.tooltip_text = result.url;
 							link.clicked.connect(() => {
-								Utils.open_uri(result.url);
+								try
+								{
+									Utils.open_uri(result.url);
+								}
+								catch(Utils.RunError error)
+								{
+									//FIXME [DEV-ART]: Replace this with inline error display?
+									GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+										this, error, Log.METHOD,
+										_("Opening website “%s” failed").printf(result.url)
+									);
+								}
 							});
 							header_hbox.add(link);
 						}

--- a/src/ui/widgets/TweaksList.vala
+++ b/src/ui/widgets/TweaksList.vala
@@ -112,7 +112,20 @@ namespace GameHub.UI.Widgets
 					url.get_style_context().add_class(Gtk.STYLE_CLASS_FLAT);
 
 					url.clicked.connect(() => {
-						Utils.open_uri(tweak.url);
+						try
+						{
+							Utils.open_uri(tweak.url);
+						}
+						catch(Utils.RunError error)
+						{
+							//FIXME [DEV-ART]: Replace this with inline error display?
+							GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+								this, error, Log.METHOD,
+								_("Opening tweak website “%s” of tweak “%s” failed").printf(
+									tweak.url, tweak.name ?? tweak.id
+								)
+							);
+						}
 					});
 
 					grid.attach(url, 2, 0, 1, 2);
@@ -126,7 +139,20 @@ namespace GameHub.UI.Widgets
 					edit.get_style_context().add_class(Gtk.STYLE_CLASS_FLAT);
 
 					edit.clicked.connect(() => {
-						Utils.open_uri(tweak.file.get_uri());
+						try
+						{
+							Utils.open_uri(tweak.file.get_uri());
+						}
+						catch(Utils.RunError error)
+						{
+							//FIXME [DEV-ART]: Replace this with inline error display?
+							GameHub.UI.Dialogs.QuickErrorDialog.display_and_log.begin(
+								this, error, Log.METHOD,
+								_("Opening editor for tweak file “%s” of tweak “%s” failed").printf(
+									tweak.file.get_path(), tweak.name ?? tweak.id
+								)
+							);
+						}
 					});
 
 					grid.attach(edit, 3, 0, 1, 2);

--- a/src/utils/FSOverlay.vala
+++ b/src/utils/FSOverlay.vala
@@ -87,7 +87,7 @@ namespace GameHub.Utils
 			}
 		}
 
-		public async void mount()
+		public async void mount() throws RunError
 		{
 			yield umount();
 
@@ -102,10 +102,13 @@ namespace GameHub.Utils
 
 			yield polkit_authenticate();
 
-			yield Utils.run({"pkexec", POLKIT_HELPER, "mount", id, options, target.get_path()}).log(GameHub.Application.log_verbose).run_sync_thread();
+			yield Utils.run({
+				"pkexec", POLKIT_HELPER,
+				"mount", id, options, target.get_path()
+			}).log(GameHub.Application.log_verbose).run_sync_thread();
 		}
 
-		public async void umount()
+		public async void umount() throws RunError
 		{
 			yield polkit_authenticate();
 

--- a/src/utils/FSUtils.vala
+++ b/src/utils/FSUtils.vala
@@ -430,7 +430,7 @@ namespace GameHub.Utils
 
 		public static void rm(string path, string? file=null, string flags="-f", HashMap<string, string>? variables=null)
 		{
-			Utils.run({"bash", "-c", "rm " + flags + " " + FSUtils.expand(path, file, variables).replace(" ", "\\ ")}).run_sync();
+			Utils.run({"bash", "-c", "rm " + flags + " " + FSUtils.expand(path, file, variables).replace(" ", "\\ ")}).run_sync_nofail();
 		}
 
 		public static void mv_up(File? path, string dirname)

--- a/src/utils/RunError.vala
+++ b/src/utils/RunError.vala
@@ -210,5 +210,23 @@ namespace GameHub.Utils
 				return RunError.from_spawn_error_literal(e, "");
 			}
 		}
+		
+		
+		/**
+		 * Like `GLib.Error.prefix` but with different output type
+		 * 
+		 * This cannot be a method as Vala does not support methods on error
+		 * domains “yet”.
+		 */
+		[PrintfFormat]
+		public static void prefix(ref RunError? error, string fmt, ...)
+		{
+			if(error == null) {
+				return;
+			}
+			
+			va_list va_list = va_list();
+			error.message = fmt.vprintf(va_list) + error.message;
+		}
 	}
 }

--- a/src/utils/RunError.vala
+++ b/src/utils/RunError.vala
@@ -1,0 +1,214 @@
+/*
+This file is part of GameHub.
+Copyright (C) 2020 Alexander Schlarb
+
+GameHub is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+GameHub is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GameHub.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+namespace GameHub.Utils
+{
+	public errordomain RunError
+	{
+		// Wrap errors returned by GLib.IOError
+		FAILED = IOError.FAILED,
+		NOT_FOUND = IOError.NOT_FOUND,
+		EXISTS = IOError.EXISTS,
+		IS_DIRECTORY = IOError.IS_DIRECTORY,
+		NOT_DIRECTORY = IOError.NOT_DIRECTORY,
+		NOT_EMPTY = IOError.NOT_EMPTY,
+		NOT_REGULAR_FILE = IOError.NOT_REGULAR_FILE,
+		NOT_SYMBOLIC_LINK = IOError.NOT_SYMBOLIC_LINK,
+		NOT_MOUNTABLE_FILE = IOError.NOT_MOUNTABLE_FILE,
+		FILENAME_TOO_LONG = IOError.FILENAME_TOO_LONG,
+		INVALID_FILENAME = IOError.INVALID_FILENAME,
+		TOO_MANY_LINKS = IOError.TOO_MANY_LINKS,
+		NO_SPACE = IOError.NO_SPACE,
+		INVALID_ARGUMENT = IOError.INVALID_ARGUMENT,
+		PERMISSION_DENIED = IOError.PERMISSION_DENIED,
+		NOT_SUPPORTED = IOError.NOT_SUPPORTED,
+		NOT_MOUNTED = IOError.NOT_MOUNTED,
+		ALREADY_MOUNTED = IOError.ALREADY_MOUNTED,
+		CLOSED = IOError.CLOSED,
+		CANCELLED = IOError.CANCELLED,
+		PENDING = IOError.PENDING,
+		READ_ONLY = IOError.READ_ONLY,
+		CANT_CREATE_BACKUP = IOError.CANT_CREATE_BACKUP,
+		WRONG_ETAG = IOError.WRONG_ETAG,
+		TIMED_OUT = IOError.TIMED_OUT,
+		WOULD_RECURSE = IOError.WOULD_RECURSE,
+		BUSY = IOError.BUSY,
+		WOULD_BLOCK = IOError.WOULD_BLOCK,
+		HOST_NOT_FOUND = IOError.HOST_NOT_FOUND,
+		WOULD_MERGE = IOError.WOULD_MERGE,
+		FAILED_HANDLED = IOError.FAILED_HANDLED,
+		TOO_MANY_OPEN_FILES = IOError.TOO_MANY_OPEN_FILES,
+		NOT_INITIALIZED = IOError.NOT_INITIALIZED,
+		ADDRESS_IN_USE = IOError.ADDRESS_IN_USE,
+		PARTIAL_INPUT = IOError.PARTIAL_INPUT,
+		INVALID_DATA = IOError.INVALID_DATA,
+		DBUS_ERROR = IOError.DBUS_ERROR,
+		HOST_UNREACHABLE = IOError.HOST_UNREACHABLE,
+		NETWORK_UNREACHABLE = IOError.NETWORK_UNREACHABLE,
+		CONNECTION_REFUSED = IOError.CONNECTION_REFUSED,
+		PROXY_FAILED = IOError.PROXY_FAILED,
+		PROXY_AUTH_FAILED = IOError.PROXY_AUTH_FAILED,
+		PROXY_NEED_AUTH = IOError.PROXY_NEED_AUTH,
+		PROXY_NOT_ALLOWED = IOError.PROXY_NOT_ALLOWED,
+		BROKEN_PIPE = IOError.BROKEN_PIPE,
+		CONNECTION_CLOSED = IOError.CONNECTION_CLOSED,
+		NOT_CONNECTED = IOError.NOT_CONNECTED,
+		MESSAGE_TOO_LARGE = IOError.MESSAGE_TOO_LARGE,
+		
+		// Extension for exit status of run programs
+		ERROR_STATUS      = 10000 + 0,
+		COMMAND_NOT_FOUND = 10000 + 1;
+		
+		public static RunError from_io_error_literal(IOError e, string prefix)
+		{
+			// Retain original error code by creating a `RunError` instance with
+			// an arbitrary error code (FAILED) and then overwriting the code
+			// attribute (we cannot use `new Error` since Vala does not allow us
+			// to access the errordomain's Quark function directly)
+			RunError error = new RunError.FAILED("%s%s", prefix, e.message);
+			error.code = e.code;
+			return error;
+		}
+		
+		[PrintfFormat]
+		public static RunError from_io_error(IOError e, string prefix_fmt, ...)
+		{
+			if(prefix_fmt.length > 0)
+			{
+				// Realize the given format string
+				va_list va_list = va_list();
+				string prefix = prefix_fmt.vprintf(va_list);
+				
+				return RunError.from_io_error_literal(e, prefix);
+			}
+			else
+			{
+				return RunError.from_io_error_literal(e, "");
+			}
+		}
+		
+		public static RunError from_spawn_error_literal(SpawnError e, string prefix)
+		{
+			// Map wrapped errno codes back to POSIX
+			int error_code = IOError.FAILED;
+			switch(e.code)
+			{
+				// Official mappings from gio/gioerror.c
+				case SpawnError.ACCES:
+				case SpawnError.PERM:
+					error_code = IOError.PERMISSION_DENIED;
+					break;
+				case SpawnError.NAMETOOLONG:
+					error_code = IOError.FILENAME_TOO_LONG;
+					break;
+				case SpawnError.NOENT:
+					error_code = IOError.NOT_FOUND;
+					break;
+				case SpawnError.NOMEM:
+					error_code = IOError.NO_SPACE;
+					break;
+				case SpawnError.NOTDIR:
+					error_code = IOError.NOT_DIRECTORY;
+					break;
+				case SpawnError.LOOP:
+					error_code = IOError.TOO_MANY_LINKS;
+					break;
+				case SpawnError.TXTBUSY:
+					error_code = IOError.BUSY;
+					break;
+				case SpawnError.MFILE:
+				case SpawnError.NFILE:
+					error_code = IOError.TOO_MANY_OPEN_FILES;
+					break;
+				case SpawnError.INVAL:
+					error_code = IOError.INVALID_ARGUMENT;
+					break;
+				case SpawnError.ISDIR:
+					error_code = IOError.IS_DIRECTORY;
+					break;
+				// Approximated mappings
+				case SpawnError.NOEXEC:
+					error_code = IOError.NOT_SUPPORTED;
+					break;
+				case SpawnError.LIBBAD:
+					error_code = IOError.INVALID_ARGUMENT;
+					break;
+				// Items without mapping (included for documentation)
+				case SpawnError.TOO_BIG:
+				case SpawnError.IO:
+				default:
+					break;
+			}
+			
+			// Also display errors that do not directly map to some POSIX error
+			// by name for extra context
+			unowned string? error_name = null;
+			switch(e.code)
+			{
+				case SpawnError.FORK:
+					error_name = "FORK";
+					break;
+				case SpawnError.READ:
+					error_name = "READ";
+					break;
+				case SpawnError.CHDIR:
+					error_name = "CHDIR";
+					break;
+				case SpawnError.FAILED:
+					error_name = "FAILED";
+					break;
+			}
+			
+			// Use mapped error code by creating a `RunError` instance with
+			// an arbitrary error code (FAILED) and then overwriting the code
+			// attribute (we cannot use `new Error` since Vala does not allow us
+			// to access the errordomain's Quark function directly)
+			RunError error;
+			if(error_name != null)
+			{
+				error = new RunError.FAILED(
+					"%s%s (%s:%s)", prefix, e.message,
+					e.domain.to_string(), error_name
+				);
+			}
+			else
+			{
+				error = new RunError.FAILED("%s%s", prefix, e.message);
+			}
+			error.code = error_code;
+			return error;
+		}
+		
+		[PrintfFormat]
+		public static RunError from_spawn_error(SpawnError e, string prefix_fmt, ...)
+		{
+			if(prefix_fmt.length > 0)
+			{
+				// Realize the given format string
+				va_list va_list = va_list();
+				string prefix = prefix_fmt.vprintf(va_list);
+				
+				return RunError.from_spawn_error_literal(e, prefix);
+			}
+			else
+			{
+				return RunError.from_spawn_error_literal(e, "");
+			}
+		}
+	}
+}


### PR DESCRIPTION
Refactors most of GameHub's code to actually fail when encountering error and ensure that an error message will be displayed instead. This is different from the current situation were errors are either completely silent or need special commandline switches to be displayed – after which they are usually completely ignored and the code carries on perform the given task (like launching a game) as if nothing happened, later causing more errors to be logged.

I originally started working on this while trying to find out why downloaded GOG DLCs weren't working in the Flatpak, but then decided that error reporting is so bad I'd rather fix that first. With these patches applied, I now get an actual error message when opening overlay-enabled games as the pk-helper is hardcoded to the wrong path in these cases and causes `pkexec` to fail.

Ugly but functional:
![Screenshot_20200623_024905](https://user-images.githubusercontent.com/246386/85348512-6307ef00-b4eb-11ea-9c42-768d8608cba2.png)
