### PR TITLE
Beginnings of gamerzilla support.

### DIFF
--- a/data/com.github.tkashkin.gamehub.gschema.xml.in
+++ b/data/com.github.tkashkin.gamehub.gschema.xml.in
@@ -261,6 +261,21 @@
 			</key>
 		</schema>
 
+		<schema path="@SCHEMA_PATH@/paths/collection/gamerzilla/" id="@SCHEMA_ID@.paths.collection.gamerzilla">
+			<key name="url" type="s">
+				<default>''</default>
+				<summary>Gamerzilla: Hubzilla url</summary>
+			</key>
+			<key name="username" type="s">
+				<default>''</default>
+				<summary>Gamerzilla: username</summary>
+			</key>
+			<key name="password" type="s">
+				<default>''</default>
+				<summary>Gamerzilla: password</summary>
+			</key>
+		</schema>
+
 	<!-- Controller -->
 		<schema path="@SCHEMA_PATH@/controller/" id="@SCHEMA_ID@.controller">
 			<key name="enabled" type="b">

--- a/src/app.vala
+++ b/src/app.vala
@@ -133,6 +133,17 @@ namespace GameHub
 		private Gtk.Settings gtk_settings;
 		private HashMap<string, CssProvider> theme_providers;
 
+		#if GAMERZILLA
+		private void* gamerzilla_thread()
+		{
+			while (true)
+			{
+				Gamerzilla.process(null);
+			}
+			return null;
+		}
+		#endif
+
 		private void init()
 		{
 			if(GameSources != null && CompatTools != null) return;
@@ -193,6 +204,29 @@ namespace GameHub
 			gtk_settings = Gtk.Settings.get_for_screen(screen);
 			gtk_settings.notify["gtk-theme-name"].connect(gtk_theme_handler);
 			gtk_theme_handler();
+			#if GAMERZILLA
+			if (!Thread.supported())
+			{
+				debug("No threading");
+			}
+			else
+			{
+				Gamerzilla.start(true, FSUtils.Paths.LocalData.GamerzillaSave);
+				FSUtils.Paths.Collection.Gamerzilla gamerzilla = FSUtils.Paths.Collection.Gamerzilla.instance;
+				if (gamerzilla.url.length != 0)
+				{
+					Gamerzilla.connect(gamerzilla.url, gamerzilla.username, gamerzilla.password);
+				}
+				try {
+					Thread<void*> thread = new Thread<void*>.try("Gamerzilla Thread.", gamerzilla_thread);
+					debug("Starting gamerzilla");
+				}
+				catch (Error e)
+				{
+					debug("Failed to start gamerzilla");
+				}
+			}
+			#endif
 		}
 
 		private void gtk_theme_handler()

--- a/src/meson.build
+++ b/src/meson.build
@@ -263,6 +263,13 @@ if manette.found()
 	sources += 'ui/dialogs/SettingsDialog/pages/general/Controller.vala'
 endif
 
+gamerzilla = dependency('gamerzilla', required: false)
+if gamerzilla.found()
+	add_global_arguments('-D', 'GAMERZILLA', language: 'vala')
+	deps += gamerzilla
+endif
+
+
 executable(
 	meson.project_name(),
 	project_config,

--- a/src/ui/dialogs/SettingsDialog/pages/general/Collection.vala
+++ b/src/ui/dialogs/SettingsDialog/pages/general/Collection.vala
@@ -30,6 +30,7 @@ namespace GameHub.UI.Dialogs.SettingsDialog.Pages.General
 		private FSUtils.Paths.Collection collection;
 		private FSUtils.Paths.Collection.GOG gog;
 		private FSUtils.Paths.Collection.Humble humble;
+		private FSUtils.Paths.Collection.Gamerzilla gamerzilla;
 
 		private FileChooserEntry collection_root;
 
@@ -40,6 +41,10 @@ namespace GameHub.UI.Dialogs.SettingsDialog.Pages.General
 
 		private Entry humble_game_dir;
 		private Entry humble_installers;
+
+		private Entry gamerzilla_url;
+		private Entry gamerzilla_username;
+		private Entry gamerzilla_password;
 
 		private int syntax_info_grid_rows = 0;
 		private Grid syntax_info_grid;
@@ -61,6 +66,7 @@ namespace GameHub.UI.Dialogs.SettingsDialog.Pages.General
 			collection = FSUtils.Paths.Collection.instance;
 			gog = FSUtils.Paths.Collection.GOG.instance;
 			humble = FSUtils.Paths.Collection.Humble.instance;
+			gamerzilla = FSUtils.Paths.Collection.Gamerzilla.instance;
 
 			collection_root = add_file_chooser(_("Collection directory"), FileChooserAction.SELECT_FOLDER, collection.root, v => { collection.root = v; update(); }).get_children().last().data as FileChooserEntry;
 
@@ -77,6 +83,15 @@ namespace GameHub.UI.Dialogs.SettingsDialog.Pages.General
 			add_header("Humble Bundle");
 			humble_game_dir = add_entry(_("Game directory") + " ($game_dir)", humble.game_dir, v => { humble.game_dir = v; update(); }, "source-humble-symbolic").get_children().last().data as Entry;
 			humble_installers = add_entry(_("Installers"), humble.installers, v => { humble.installers = v; update(); }, "source-humble-symbolic").get_children().last().data as Entry;
+
+			#if GAMERZILLA
+			add_separator();
+
+			add_header("Gamerzilla");
+			gamerzilla_url = add_entry(_("Hubzilla URL"), gamerzilla.url, v => { gamerzilla.url = v; update(); }, "source-gamerzilla-symbolic").get_children().last().data as Entry;
+			gamerzilla_username = add_entry(_("Username"), gamerzilla.username, v => { gamerzilla.username = v; update(); }, "source-gamerzilla-symbolic").get_children().last().data as Entry;
+			gamerzilla_password = add_entry(_("Password"), gamerzilla.password, v => { gamerzilla.password = v; update(); }, "source-gamerzilla-symbolic").get_children().last().data as Entry;
+			#endif
 
 			syntax_info_grid = new Grid();
 			syntax_info_grid.column_spacing = 72;

--- a/src/utils/FSUtils.vala
+++ b/src/utils/FSUtils.vala
@@ -85,6 +85,7 @@ namespace GameHub.Utils
 				public const string Home = "~/.local/share/" + ProjectConfig.PROJECT_NAME;
 				public const string Tweaks = FSUtils.Paths.LocalData.Home + "/tweaks";
 				public const string DOSBoxConfigs = FSUtils.Paths.LocalData.Home + "/compat/dosbox";
+				public const string GamerzillaSave = FSUtils.Paths.LocalData.Home + "/gamerzilla/";
 			}
 
 			public class Config
@@ -283,6 +284,31 @@ namespace GameHub.Utils
 							if(_instance == null)
 							{
 								_instance = new Humble();
+							}
+							return _instance;
+						}
+					}
+				}
+
+				public class Gamerzilla: GameHub.Settings.SettingsSchema
+				{
+					public string url { get; set; }
+					public string username { get; set; }
+					public string password { get; set; }
+
+					public Gamerzilla()
+					{
+						base(ProjectConfig.PROJECT_NAME + ".paths.collection.gamerzilla");
+					}
+
+					private static Gamerzilla? _instance;
+					public static unowned Gamerzilla instance
+					{
+						get
+						{
+							if(_instance == null)
+							{
+								_instance = new Gamerzilla();
 							}
 							return _instance;
 						}
@@ -497,6 +523,7 @@ namespace GameHub.Utils
 			mkdir(FSUtils.Paths.LocalData.Home);
 			mkdir(FSUtils.Paths.LocalData.Tweaks);
 			mkdir(FSUtils.Paths.LocalData.DOSBoxConfigs);
+			mkdir(FSUtils.Paths.LocalData.GamerzillaSave);
 
 			mkdir(FSUtils.Paths.Config.Home);
 			mkdir(FSUtils.Paths.Config.Tweaks);


### PR DESCRIPTION
Gamerzilla is an open source trophy/achievement system I've been building. The web display piece is currently handled by a plugin for Hubzilla. Additional implementations could be made in the future. LibGamerzilla is a library for games to upload when trophies are acquired and progress. To avoid having to enter your Hubzilla url, username, and password in every game, the library was designed with a game launcher in mind.

This pull request implements the listener and communication with Hubzilla. It is mainly to seek feedback on the idea. The plan is for Gamehub to get the game image from LibGamerzilla and be able to display trophies.

Right now the settings are on the Collections page which probably isn't the right place.