### PR TITLE
Tray icon (aka AppIndicator) support

### DIFF
--- a/data/com.github.tkashkin.gamehub.gschema.xml.in
+++ b/data/com.github.tkashkin.gamehub.gschema.xml.in
@@ -128,6 +128,10 @@
 				<default>true</default>
 				<summary>Import tags</summary>
 			</key>
+			<key name="use-app-indicator" type="b">
+				<default>false</default>
+				<summary>Use tray icon</summary>
+			</key>
 		</schema>
 
 	<!-- Auth -->

--- a/src/app.vala
+++ b/src/app.vala
@@ -35,7 +35,7 @@ namespace GameHub
 	public class Application: Gtk.Application
 	{
 		public static Application instance;
-		public static UI.Widgets.AppIndicator appIndicator;
+		public static UI.Widgets.AppIndicator app_indicator;
 
 		public static bool log_auth = false;
 		public static bool log_downloader = false;
@@ -195,7 +195,10 @@ namespace GameHub
 			gtk_settings = Gtk.Settings.get_for_screen(screen);
 			gtk_settings.notify["gtk-theme-name"].connect(gtk_theme_handler);
 			gtk_theme_handler();
-			appIndicator = new UI.Widgets.AppIndicator();
+			if (Settings.UI.Behavior.instance.use_app_indicator)
+			{
+				app_indicator = new UI.Widgets.AppIndicator();
+			}
 		}
 
 		private void gtk_theme_handler()

--- a/src/app.vala
+++ b/src/app.vala
@@ -35,7 +35,6 @@ namespace GameHub
 	public class Application: Gtk.Application
 	{
 		public static Application instance;
-		public static UI.Widgets.AppIndicator? app_indicator = null;
 
 		public static bool log_auth = false;
 		public static bool log_downloader = false;
@@ -195,6 +194,11 @@ namespace GameHub
 			gtk_settings = Gtk.Settings.get_for_screen(screen);
 			gtk_settings.notify["gtk-theme-name"].connect(gtk_theme_handler);
 			gtk_theme_handler();
+
+			if (Settings.UI.Behavior.instance.use_app_indicator)
+			{
+				new UI.Widgets.AppIndicator();
+			}
 		}
 
 		private void gtk_theme_handler()

--- a/src/app.vala
+++ b/src/app.vala
@@ -195,10 +195,6 @@ namespace GameHub
 			gtk_settings = Gtk.Settings.get_for_screen(screen);
 			gtk_settings.notify["gtk-theme-name"].connect(gtk_theme_handler);
 			gtk_theme_handler();
-			if (Settings.UI.Behavior.instance.use_app_indicator)
-			{
-				app_indicator = new UI.Widgets.AppIndicator();
-			}
 		}
 
 		private void gtk_theme_handler()

--- a/src/app.vala
+++ b/src/app.vala
@@ -35,7 +35,7 @@ namespace GameHub
 	public class Application: Gtk.Application
 	{
 		public static Application instance;
-		public static UI.Widgets.AppIndicator app_indicator;
+		public static UI.Widgets.AppIndicator? app_indicator = null;
 
 		public static bool log_auth = false;
 		public static bool log_downloader = false;

--- a/src/app.vala
+++ b/src/app.vala
@@ -19,7 +19,6 @@ along with GameHub.  If not, see <https://www.gnu.org/licenses/>.
 using Gtk;
 using Gdk;
 using Gee;
-using AppIndicator;
 
 using GameHub.Data;
 using GameHub.Data.DB;
@@ -36,6 +35,7 @@ namespace GameHub
 	public class Application: Gtk.Application
 	{
 		public static Application instance;
+		public static UI.Widgets.AppIndicator appIndicator;
 
 		public static bool log_auth = false;
 		public static bool log_downloader = false;
@@ -76,7 +76,6 @@ namespace GameHub
 
 		public const string ACCEL_SETTINGS                         = "<Control>S";
 
-		private const string APP_INDICATOR_ID                      = "gamehub.indicator";
 
 		private const GLib.ActionEntry[] action_entries = {
 			{ ACTION_SETTINGS,                        action_settings },
@@ -135,7 +134,6 @@ namespace GameHub
 		private Screen screen;
 		private Gtk.Settings gtk_settings;
 		private HashMap<string, CssProvider> theme_providers;
-		private Indicator appIndicator;
 
 		private void init()
 		{
@@ -197,10 +195,7 @@ namespace GameHub
 			gtk_settings = Gtk.Settings.get_for_screen(screen);
 			gtk_settings.notify["gtk-theme-name"].connect(gtk_theme_handler);
 			gtk_theme_handler();
-
-			appIndicator = new Indicator(APP_INDICATOR_ID, "scalable/actions/gamehub-symbolic.svg", IndicatorCategory.APPLICATION_STATUS);
-			appIndicator.set_status(IndicatorStatus.ACTIVE);
-			appIndicator.set_title("GameHub");
+			appIndicator = new UI.Widgets.AppIndicator();
 		}
 
 		private void gtk_theme_handler()

--- a/src/app.vala
+++ b/src/app.vala
@@ -19,6 +19,7 @@ along with GameHub.  If not, see <https://www.gnu.org/licenses/>.
 using Gtk;
 using Gdk;
 using Gee;
+using AppIndicator;
 
 using GameHub.Data;
 using GameHub.Data.DB;
@@ -74,6 +75,8 @@ namespace GameHub
 		public const string ACTION_GAME_PROPERTIES                 = "game.properties";
 
 		public const string ACCEL_SETTINGS                         = "<Control>S";
+
+		private const string APP_INDICATOR_ID                      = "gamehub.indicator";
 
 		private const GLib.ActionEntry[] action_entries = {
 			{ ACTION_SETTINGS,                        action_settings },
@@ -132,6 +135,7 @@ namespace GameHub
 		private Screen screen;
 		private Gtk.Settings gtk_settings;
 		private HashMap<string, CssProvider> theme_providers;
+		private Indicator appIndicator;
 
 		private void init()
 		{
@@ -193,6 +197,10 @@ namespace GameHub
 			gtk_settings = Gtk.Settings.get_for_screen(screen);
 			gtk_settings.notify["gtk-theme-name"].connect(gtk_theme_handler);
 			gtk_theme_handler();
+
+			appIndicator = new Indicator(APP_INDICATOR_ID, "scalable/actions/gamehub-symbolic.svg", IndicatorCategory.APPLICATION_STATUS);
+			appIndicator.set_status(IndicatorStatus.ACTIVE);
+			appIndicator.set_title("GameHub");
 		}
 
 		private void gtk_theme_handler()

--- a/src/data/adapters/GamesAdapter.vala
+++ b/src/data/adapters/GamesAdapter.vala
@@ -133,6 +133,14 @@ namespace GameHub.Data.Adapters
 			}
 		}
 
+		public Gee.List<Game> get_last_launched_games(int count = 10)
+		{
+			ArrayList<Game> sorted_games = new ArrayList<Game>();
+			sorted_games.add_all(games);
+			sorted_games.sort((g1,g2) => {return (g2.last_launch - g1.last_launch) > 0 ? 1 : -1;});
+			return sorted_games.slice(0, int.min(count, sorted_games.size));
+		}
+
 		public void load_games(Utils.FutureResult<GameSource> loaded_callback)
 		{
 			Utils.thread("GamesAdapterLoad", () => {

--- a/src/meson.build
+++ b/src/meson.build
@@ -154,6 +154,7 @@ sources = [
 
 	'ui/widgets/AutoSizeImage.vala',
 	'ui/widgets/ActionButton.vala',
+	'ui/widgets/AppIndicator.vala',
 	'ui/widgets/FileChooserEntry.vala',
 	'ui/widgets/ExtendedStackSwitcher.vala',
 	'ui/widgets/ImagesDownloadPopover.vala',

--- a/src/meson.build
+++ b/src/meson.build
@@ -30,6 +30,7 @@ deps = [
 	dependency('libxml-2.0'),
 	dependency('gio-unix-2.0'),
 	dependency('zlib'),
+	dependency('appindicator3-0.1'),
 	meson.get_compiler('vala').find_library('posix'),
 	meson.get_compiler('vala').find_library('linux')
 ]

--- a/src/settings/UI.vala
+++ b/src/settings/UI.vala
@@ -201,6 +201,7 @@ namespace GameHub.Settings.UI
 		public bool grid_doubleclick { get; set; }
 		public bool merge_games { get; set; }
 		public bool import_tags { get; set; }
+		public bool use_app_indicator { get; set; }
 
 		public Behavior()
 		{

--- a/src/ui/dialogs/SettingsDialog/pages/ui/Behavior.vala
+++ b/src/ui/dialogs/SettingsDialog/pages/ui/Behavior.vala
@@ -53,13 +53,13 @@ namespace GameHub.UI.Dialogs.SettingsDialog.Pages.UI
 
 			add_switch(_("Show tray icon"), settings.use_app_indicator, v => {
 				settings.use_app_indicator = v;
-				if (Application.app_indicator != null)
+				if (Widgets.AppIndicator.instance != null)
 				{
-					Application.app_indicator.visible = v;
+					Widgets.AppIndicator.instance.visible = v;
 				}
 				else if (v)
 				{
-					Application.app_indicator = new GameHub.UI.Widgets.AppIndicator();
+					new Widgets.AppIndicator();
 				}
 			});
 		}

--- a/src/ui/dialogs/SettingsDialog/pages/ui/Behavior.vala
+++ b/src/ui/dialogs/SettingsDialog/pages/ui/Behavior.vala
@@ -48,6 +48,20 @@ namespace GameHub.UI.Dialogs.SettingsDialog.Pages.UI
 			add_separator();
 
 			add_switch(_("Use imported tags"), settings.import_tags, v => { settings.import_tags = v; });
+
+			add_separator();
+
+			add_switch(_("Show tray icon"), settings.use_app_indicator, v => {
+				settings.use_app_indicator = v;
+				if (v)
+				{
+					Application.app_indicator = new GameHub.UI.Widgets.AppIndicator();
+				}
+				else
+				{
+					Application.app_indicator = null;
+				}
+			});
 		}
 	}
 }

--- a/src/ui/dialogs/SettingsDialog/pages/ui/Behavior.vala
+++ b/src/ui/dialogs/SettingsDialog/pages/ui/Behavior.vala
@@ -53,13 +53,13 @@ namespace GameHub.UI.Dialogs.SettingsDialog.Pages.UI
 
 			add_switch(_("Show tray icon"), settings.use_app_indicator, v => {
 				settings.use_app_indicator = v;
-				if (v)
+				if (Application.app_indicator != null)
+				{
+					Application.app_indicator.visible = v;
+				}
+				else if (v)
 				{
 					Application.app_indicator = new GameHub.UI.Widgets.AppIndicator();
-				}
-				else
-				{
-					Application.app_indicator = null;
 				}
 			});
 		}

--- a/src/ui/views/GamesView/GamesView.vala
+++ b/src/ui/views/GamesView/GamesView.vala
@@ -234,6 +234,12 @@ namespace GameHub.UI.Views.GamesView
 			games_adapter = new GamesAdapter();
 			games_adapter.cache_loaded.connect(update_view);
 
+			games_adapter.cache_loaded.connect(()=>
+			{
+				if (GameHub.Application.app_indicator != null)
+					GameHub.Application.app_indicator.set_games_shortcuts(games_adapter);
+			});
+
 			filter.mode_changed.connect(update_view);
 			search.search_changed.connect(() => {
 				games_adapter.filter_search_query = search.text;

--- a/src/ui/views/GamesView/GamesView.vala
+++ b/src/ui/views/GamesView/GamesView.vala
@@ -415,10 +415,7 @@ namespace GameHub.UI.Views.GamesView
 
 			load_games();
 
-			if (Settings.UI.Behavior.instance.use_app_indicator)
-			{
-				GameHub.Application.app_indicator = new UI.Widgets.AppIndicator();
-			}
+			Widgets.AppIndicator.set_games_adapter(games_adapter);
 		}
 
 		public override void attach_to_window(MainWindow wnd)

--- a/src/ui/views/GamesView/GamesView.vala
+++ b/src/ui/views/GamesView/GamesView.vala
@@ -234,12 +234,6 @@ namespace GameHub.UI.Views.GamesView
 			games_adapter = new GamesAdapter();
 			games_adapter.cache_loaded.connect(update_view);
 
-			games_adapter.cache_loaded.connect(()=>
-			{
-				if (GameHub.Application.app_indicator != null)
-					GameHub.Application.app_indicator.set_games_shortcuts(games_adapter);
-			});
-
 			filter.mode_changed.connect(update_view);
 			search.search_changed.connect(() => {
 				games_adapter.filter_search_query = search.text;
@@ -420,6 +414,11 @@ namespace GameHub.UI.Views.GamesView
 			games_adapter.group_mode = filters_popover.group_mode;
 
 			load_games();
+
+			if (Settings.UI.Behavior.instance.use_app_indicator)
+			{
+				GameHub.Application.app_indicator = new UI.Widgets.AppIndicator();
+			}
 		}
 
 		public override void attach_to_window(MainWindow wnd)
@@ -790,6 +789,11 @@ namespace GameHub.UI.Views.GamesView
 			game.image = image;
 			game.image_vertical = image_vertical;
 			game.save();
+		}
+
+		public unowned GamesAdapter get_games_adapter()
+		{
+			return games_adapter;
 		}
 
 		#if UNITY

--- a/src/ui/widgets/AppIndicator.vala
+++ b/src/ui/widgets/AppIndicator.vala
@@ -30,8 +30,8 @@ namespace GameHub.UI.Widgets
 {
     public class AppIndicator : Object
     {
+        public static AppIndicator instance;
         private Indicator app_indicator;
-        private unowned GamesAdapter games_adapter;
         private const string APP_INDICATOR_ID = "gamehub.indicator";
         private GLib.List<unowned Window> visible_windows;
         private Gtk.Menu menu;
@@ -49,11 +49,30 @@ namespace GameHub.UI.Widgets
 			app_indicator.set_status(IndicatorStatus.ACTIVE);
 			app_indicator.set_title("GameHub");
 
-            games_adapter = GamesView.instance.get_games_adapter();
-			games_adapter.cache_loaded.connect(() => { setup_menu(games_adapter.get_last_launched_games(RECENT_GAMES_COUNT)); });
+            if (GamesView.instance != null)
+            {
+                connect_games_adapter(GamesView.instance.get_games_adapter());
+            }
+            else
+            {
+                setup_menu();
+            }
+
+            instance = this;
         }
 
-        private void setup_menu(Gee.List<Game> games)
+        public static void set_games_adapter(GamesAdapter games_adapter) {
+            if (instance != null) {
+                instance.connect_games_adapter(games_adapter);
+            }
+        }
+
+        private void connect_games_adapter(GamesAdapter games_adapter) {
+            setup_menu(games_adapter.get_last_launched_games(RECENT_GAMES_COUNT));
+            games_adapter.cache_loaded.connect(() => { setup_menu(games_adapter.get_last_launched_games(RECENT_GAMES_COUNT)); });
+        }
+
+        private void setup_menu(Gee.List<Game>? games = null)
         {
             menu = new Gtk.Menu();
 

--- a/src/ui/widgets/AppIndicator.vala
+++ b/src/ui/widgets/AppIndicator.vala
@@ -61,7 +61,7 @@ namespace GameHub.UI.Widgets
                 visibleWindows = new List<unowned Window>();
                 activeWindows.foreach ((window) =>
                 {
-                    if (window.visible)
+                    if (window.visible && window.transient_for == UI.Windows.MainWindow.instance)
                     {
                         visibleWindows.append(window);
                         window.visible = false;
@@ -75,6 +75,7 @@ namespace GameHub.UI.Widgets
                     window.visible = true;
                 });
             }
+            UI.Windows.MainWindow.instance.visible = !isMainWindowVisible;
 		}
 
         private void quit()

--- a/src/ui/widgets/AppIndicator.vala
+++ b/src/ui/widgets/AppIndicator.vala
@@ -31,7 +31,7 @@ namespace GameHub.UI.Widgets
 
         construct
         {
-			appIndicator = new Indicator(APP_INDICATOR_ID, "gamehub-symbolic", IndicatorCategory.APPLICATION_STATUS);
+            appIndicator = new Indicator(APP_INDICATOR_ID, "gamehub-symbolic", IndicatorCategory.APPLICATION_STATUS);
 			appIndicator.set_status(IndicatorStatus.ACTIVE);
 			appIndicator.set_title("GameHub");
 

--- a/src/ui/widgets/AppIndicator.vala
+++ b/src/ui/widgets/AppIndicator.vala
@@ -1,0 +1,85 @@
+/*
+This file is part of GameHub.
+Copyright(C) 2018-2019 Anatoliy Kashkin
+
+GameHub is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+GameHub is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GameHub.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/* Based on Granite.Widgets.AlertView */
+
+using Gtk;
+using AppIndicator;
+
+namespace GameHub.UI.Widgets
+{
+    public class AppIndicator : Object
+    {
+        private Indicator appIndicator;
+        private const string APP_INDICATOR_ID = "gamehub.indicator";
+        List<unowned Window> visibleWindows;
+
+        construct
+        {
+			appIndicator = new Indicator(APP_INDICATOR_ID, "gamehub-symbolic", IndicatorCategory.APPLICATION_STATUS);
+			appIndicator.set_status(IndicatorStatus.ACTIVE);
+			appIndicator.set_title("GameHub");
+
+            Gtk.Menu menu = new Gtk.Menu();
+            
+			Gtk.ImageMenuItem show_item = new Gtk.ImageMenuItem();
+			show_item.set_label("Show/Hide");
+            show_item.activate.connect(show_hide);
+            Gtk.ImageMenuItem quit_item = new Gtk.ImageMenuItem();
+            quit_item.set_label("Quit");
+            quit_item.activate.connect(quit);
+            
+            menu.append(show_item);
+            menu.append(quit_item);
+			menu.show_all();
+
+            appIndicator.set_menu(menu);
+        }
+
+		private void show_hide()
+		{
+            List<unowned Window> activeWindows = Gtk.Window.list_toplevels();
+            bool isMainWindowVisible = UI.Windows.MainWindow.instance.visible;
+
+            if (isMainWindowVisible)
+            {
+                visibleWindows = new List<unowned Window>();
+                activeWindows.foreach ((window) =>
+                {
+                    if (window.visible)
+                    {
+                        visibleWindows.append(window);
+                        window.visible = false;
+                    }
+                });
+            }
+            else
+            {
+                visibleWindows.foreach((window) =>
+                {
+                    window.visible = true;
+                });
+            }
+		}
+
+        private void quit()
+        {
+            UI.Windows.MainWindow.instance.close();
+        }
+    }
+}

--- a/src/ui/windows/MainWindow.vala
+++ b/src/ui/windows/MainWindow.vala
@@ -69,9 +69,23 @@ namespace GameHub.UI.Windows
 
 			saved_state = SavedState.Window.instance;
 
-			delete_event.connect(() => { quit(); return false; });
+			delete_event.connect(on_delete);
 
 			restore_saved_state();
+		}
+
+		private bool on_delete()
+		{
+			if (GameHub.Application.app_indicator != null && GameHub.Application.app_indicator.visible)
+			{
+				visible = false;
+				return true;
+			}
+			else
+			{
+				quit();
+				return false;
+			}
 		}
 
 		public void add_view(BaseView view, bool show=true)

--- a/src/ui/windows/MainWindow.vala
+++ b/src/ui/windows/MainWindow.vala
@@ -19,6 +19,7 @@ along with GameHub.  If not, see <https://www.gnu.org/licenses/>.
 using Gtk;
 using GameHub.UI.Views;
 using GameHub.Settings;
+using GameHub.UI.Widgets;
 
 namespace GameHub.UI.Windows
 {
@@ -76,7 +77,7 @@ namespace GameHub.UI.Windows
 
 		private bool on_delete()
 		{
-			if (GameHub.Application.app_indicator != null && GameHub.Application.app_indicator.visible)
+			if (Widgets.AppIndicator.instance != null && Widgets.AppIndicator.instance.visible)
 			{
 				visible = false;
 				return true;


### PR DESCRIPTION
Gnome ditched the system tray, but it's still useful on other DEs like KDE, Cinnamon, XFCE, etc.
I tried to generate as little coupling as I could, but maybe the way I'm getting the games information isn't as clean as it could be.
I'm open to suggestions for improving it, of course.