### PR TITLE
Run wineboot with tweaks

### DIFF
--- a/src/data/compat/Wine.vala
+++ b/src/data/compat/Wine.vala
@@ -318,7 +318,12 @@ namespace GameHub.Data.Compat
 				}
 			}
 
-			yield Utils.run(cmd).dir(runnable.install_dir.get_path()).env(prepare_env(runnable)).run_sync_thread();
+			var task = Utils.run(cmd).dir(runnable.install_dir.get_path()).env(prepare_env(runnable));
+			if(runnable is TweakableGame)
+			{
+				task.tweaks(((TweakableGame) runnable).get_enabled_tweaks(this));
+			}
+			yield task.run_sync_thread();
 		}
 
 		protected async void winetricks(Runnable runnable)


### PR DESCRIPTION
Hi,

I recently started using GameHub and tried some gaming workflow and tweaks. I notably tried to create tweaks to enable/disable esynf/fsync when using the system's wine installation, and found out that using the tweak crashed wine. I narrowed the issue to the fact that the env var wasn't passed on when running wineboot, so I added the tweaks enabling to wineboot execution.

It might be a little random as I've not created an issue or anything, but as I couldn't find contribution instructions, I decided to just go ahead wit the PR and see. Tell me if I did anything wrong and if there's any process I should follow. :) 