### PR TITLE
Prepare wineboot task like wine

### DIFF
--- a/src/data/compat/tools/wine/Wine.vala
+++ b/src/data/compat/tools/wine/Wine.vala
@@ -262,7 +262,8 @@ namespace GameHub.Data.Compat.Tools.Wine
 					cmd += arg;
 				}
 			}
-			var task = Utils.exec(cmd).dir(runnable.install_dir.get_path());
+			var task = runnable.prepare_exec_task(cmd, args);
+			task.dir(runnable.install_dir.get_path());
 			apply_env(runnable, task, wine_options);
 			yield task.sync_thread();
 		}


### PR DESCRIPTION
Hi! It's been a while. I opened #533 back in January for an issue when running wineboot with esync/fsync enabled as the env var was not set for wineboot execution. It was supposed to be fixed in the refactoring branch that will be the 1.0, but it wasn't in my testing, so I fixed it again in this branch but never submitted the change.

It's done now. :)