### PR TITLE
Update the Finnish translation

### DIFF
--- a/po/fi.po
+++ b/po/fi.po
@@ -1747,7 +1747,7 @@ msgstr "%dt"
 #, c-format
 msgctxt "time"
 msgid "%dm"
-msgstr "%dkk"
+msgstr "%dm"
 
 #: src/utils/Utils.vala:464
 #, c-format


### PR DESCRIPTION
In this context, the original m stands for minutes, not months. Therefore the Finnish abbreviation is "m" as in "minuutti" (minute) and not "kk" as in "kuukausi" (month)