### PR TITLE
Fix custom compat emulator

### DIFF
--- a/src/data/Emulator.vala
+++ b/src/data/Emulator.vala
@@ -59,7 +59,7 @@ namespace GameHub.Data
 				save();
 			}
 		}
-		public File? get_file(string? p, bool from_all_overlays=true)
+		public File? get_file(string? p)
 		{
 			if(p == null || p.length == 0 || install_dir == null) return null;
 			var path = p;

--- a/src/data/Emulator.vala
+++ b/src/data/Emulator.vala
@@ -28,7 +28,58 @@ namespace GameHub.Data
 		public signal void removed();
 
 		public override File? executable { owned get; set; }
-		public override File? work_dir { owned get; set; }
+		//  public override File? work_dir { owned get; set; }
+		public string? work_dir_path;
+		public override File? work_dir
+		{
+			owned get
+			{
+				if(install_dir == null) return null;
+				if(work_dir_path == null || work_dir_path.length == 0) return install_dir;
+				return get_file(work_dir_path);
+			}
+			set
+			{
+				if(value != null && value.query_exists() && install_dir != null && install_dir.query_exists())
+				{
+					File[] dirs = { install_dir };
+					foreach(var dir in dirs)
+					{
+						if(value.get_path().has_prefix(dir.get_path()))
+						{
+							work_dir_path = value.get_path().replace(dir.get_path(), "$game_dir/");
+							break;
+						}
+					}
+				}
+				else
+				{
+					work_dir_path = null;
+				}
+				save();
+			}
+		}
+		public File? get_file(string? p, bool from_all_overlays=true)
+		{
+			if(p == null || p.length == 0 || install_dir == null) return null;
+			var path = p;
+			if(!path.has_prefix("$game_dir/") && !path.has_prefix("/"))
+			{
+				path = "$game_dir/" + path;
+			}
+			File[] dirs = { install_dir };
+			var variables = new HashMap<string, string>();
+			foreach(var dir in dirs)
+			{
+				variables.set("game_dir", dir.get_path());
+				var file = FSUtils.file(path, null, variables);
+				if(file != null && file.query_exists())
+				{
+					return file;
+				}
+			}
+			return null;
+		}
 		public Installer? installer;
 
 		public string? game_executable_pattern { get; set; }

--- a/src/ui/dialogs/CompatRunDialog.vala
+++ b/src/ui/dialogs/CompatRunDialog.vala
@@ -129,13 +129,21 @@ namespace GameHub.UI.Dialogs
 
 			if(game is Emulator)
 			{
-				emulated_game.is_running = true;
-				emulated_game.update_status();
+				if(emulated_game != null)
+				{
+					emulated_game.is_running = true;
+					emulated_game.update_status();
+				}
+
 				compat_tool_picker.selected.run_emulator.begin(game as Emulator, emulated_game, launch_in_game_dir, (obj, res) => {
 					compat_tool_picker.selected.run_emulator.end(res);
 					Timeout.add_seconds(1, () => {
-						Runnable.IsLaunched = game.is_running = emulated_game.is_running = false;
-						emulated_game.update_status();
+						Runnable.IsLaunched = game.is_running = false;
+						if(emulated_game != null)
+						{
+							emulated_game.update_status();
+							emulated_game.is_running = false;
+						}
 						return Source.REMOVE;
 					});
 					destroy();


### PR DESCRIPTION
Some fixes when using a custom emulator with a compat tool (Proton):

* When an emulator is started without a game e.g. from the settings dialog then the silently called compat run dialog is missing some `null` checks for the `emulated_game`.
* After initialization the `work_dir` for an emulator is never refreshed resulting in being an unexpected `null` further down the line for `emu.work_dir` at https://github.com/tkashkin/GameHub/blob/ebb46ff0b394fbb004e8a3d2bfc4f47410dec18f/src/data/compat/Wine.vala#L159
  The refresh logic is a (almost) direct copy from `Game.vala`.