### PR TITLE
Implement SteamGridDB filter settings

### DIFF
--- a/data/com.github.tkashkin.gamehub.gschema.xml.in
+++ b/data/com.github.tkashkin.gamehub.gschema.xml.in
@@ -311,6 +311,14 @@
 				<default>'@PREF_API_KEY_STEAMGRIDDB@'</default>
 				<summary>SteamGridDB API key</summary>
 			</key>
+			<key name="filter-humor" type="s">
+				<default>'false'</default>
+				<summary>SteamGridDB humor filter setting</summary>
+			</key>
+			<key name="filter-nsfw" type="s">
+				<default>'false'</default>
+				<summary>SteamGridDB NSFW filter setting</summary>
+			</key>
 		</schema>
 
 		<schema path="@SCHEMA_PATH@/providers/images/jinx-sgvi/" id="@SCHEMA_ID@.providers.images.jinx-sgvi">

--- a/src/data/providers/images/SteamGridDB.vala
+++ b/src/data/providers/images/SteamGridDB.vala
@@ -40,82 +40,6 @@ namespace GameHub.Data.Providers.Images
 			set { Settings.Providers.Images.SteamGridDB.instance.enabled = value; }
 		}
 
-		public enum FilterHumor
-		{
-			TRUE, FALSE, ANY;
-
-			public string value()
-			{
-				switch (this)
-				{
-					case FilterHumor.TRUE:  return "true";
-					case FilterHumor.FALSE: return "false";
-					case FilterHumor.ANY:   return "any";
-				}
-				assert_not_reached();
-			}
-
-			public static FilterHumor from_string(string setting)
-			{
-				switch (setting)
-				{
-					case "true":  return FilterHumor.TRUE;
-					case "false": return FilterHumor.FALSE;
-					case "any":   return FilterHumor.ANY;
-				}
-				assert_not_reached();
-			}
-
-			public string name()
-			{
-				switch(this)
-				{
-					case FilterHumor.TRUE:  return C_("imagesource_steamgriddb_image_filter", "True");
-					case FilterHumor.FALSE: return C_("imagesource_steamgriddb_image_filter", "False");
-					case FilterHumor.ANY:   return C_("imagesource_steamgriddb_image_filter", "Any");
-				}
-				assert_not_reached();
-			}
-		}
-
-		public enum FilterNsfw
-		{
-			TRUE, FALSE, ANY;
-
-			public string value()
-			{
-				switch (this)
-				{
-					case FilterNsfw.TRUE:  return "true";
-					case FilterNsfw.FALSE: return "false";
-					case FilterNsfw.ANY:   return "any";
-				}
-				assert_not_reached();
-			}
-
-			public static FilterNsfw from_string(string setting)
-			{
-				switch (setting)
-				{
-					case "true":  return FilterNsfw.TRUE;
-					case "false": return FilterNsfw.FALSE;
-					case "any":   return FilterNsfw.ANY;
-				}
-				assert_not_reached();
-			}
-
-			public string name()
-			{
-				switch(this)
-				{
-					case FilterNsfw.TRUE:  return C_("imagesource_steamgriddb_image_filter", "True");
-					case FilterNsfw.FALSE: return C_("imagesource_steamgriddb_image_filter", "False");
-					case FilterNsfw.ANY:   return C_("imagesource_steamgriddb_image_filter", "Any");
-				}
-				assert_not_reached();
-			}
-		}
-
 		public override async ArrayList<ImagesProvider.Result> images(Game game)
 		{
 			var results = new ArrayList<ImagesProvider.Result>();
@@ -275,10 +199,10 @@ namespace GameHub.Data.Providers.Images
 				combo_filter_humor.halign = Gtk.Align.END;
 				combo_filter_humor.valign = Gtk.Align.CENTER;
 				combo_filter_humor.hexpand = false;
-				combo_filter_humor.append(FilterHumor.TRUE.value(), FilterHumor.TRUE.name());
-				combo_filter_humor.append(FilterHumor.FALSE.value(), FilterHumor.FALSE.name());
-				combo_filter_humor.append(FilterHumor.ANY.value(), FilterHumor.ANY.name());
-				combo_filter_humor.set_active_id(FilterHumor.from_string(settings.filter_humor).value());
+				combo_filter_humor.append("true", C_("imagesource_steamgriddb_image_filter", "True"));
+				combo_filter_humor.append("false", C_("imagesource_steamgriddb_image_filter", "False"));
+				combo_filter_humor.append("any", C_("imagesource_steamgriddb_image_filter", "Any"));
+				combo_filter_humor.set_active_id(settings.filter_humor);
 				combo_filter_humor.changed.connect(() => { settings.filter_humor = combo_filter_humor.get_active_id(); });
 
 				grid.attach(label_filter_humor, 0, 1);
@@ -293,10 +217,10 @@ namespace GameHub.Data.Providers.Images
 				combo_filter_nsfw.halign = Gtk.Align.END;
 				combo_filter_nsfw.valign = Gtk.Align.CENTER;
 				combo_filter_nsfw.hexpand = false;
-				combo_filter_nsfw.append(FilterNsfw.TRUE.value(), FilterNsfw.TRUE.name());
-				combo_filter_nsfw.append(FilterNsfw.FALSE.value(), FilterNsfw.FALSE.name());
-				combo_filter_nsfw.append(FilterNsfw.ANY.value(), FilterNsfw.ANY.name());
-				combo_filter_nsfw.set_active_id(FilterNsfw.from_string(settings.filter_nsfw).value());
+				combo_filter_nsfw.append("true", C_("imagesource_steamgriddb_image_filter", "True"));
+				combo_filter_nsfw.append("false", C_("imagesource_steamgriddb_image_filter", "False"));
+				combo_filter_nsfw.append("any", C_("imagesource_steamgriddb_image_filter", "Any"));
+				combo_filter_nsfw.set_active_id(settings.filter_nsfw);
 				combo_filter_nsfw.changed.connect(() => { settings.filter_nsfw = combo_filter_nsfw.get_active_id(); });
 
 				grid.attach(label_filter_nsfw, 0, 2);

--- a/src/data/providers/images/SteamGridDB.vala
+++ b/src/data/providers/images/SteamGridDB.vala
@@ -199,9 +199,9 @@ namespace GameHub.Data.Providers.Images
 				combo_filter_humor.halign = Gtk.Align.END;
 				combo_filter_humor.valign = Gtk.Align.CENTER;
 				combo_filter_humor.hexpand = false;
-				combo_filter_humor.append("true", C_("imagesource_steamgriddb_image_filter", "True"));
-				combo_filter_humor.append("false", C_("imagesource_steamgriddb_image_filter", "False"));
-				combo_filter_humor.append("any", C_("imagesource_steamgriddb_image_filter", "Any"));
+				combo_filter_humor.append("true", C_("imagesource_steamgriddb_image_filter", "Only"));
+				combo_filter_humor.append("false", C_("imagesource_steamgriddb_image_filter", "None"));
+				combo_filter_humor.append("any", C_("imagesource_steamgriddb_image_filter", "Doesn't matter"));
 				combo_filter_humor.set_active_id(settings.filter_humor);
 				combo_filter_humor.changed.connect(() => { settings.filter_humor = combo_filter_humor.get_active_id(); });
 
@@ -217,9 +217,9 @@ namespace GameHub.Data.Providers.Images
 				combo_filter_nsfw.halign = Gtk.Align.END;
 				combo_filter_nsfw.valign = Gtk.Align.CENTER;
 				combo_filter_nsfw.hexpand = false;
-				combo_filter_nsfw.append("true", C_("imagesource_steamgriddb_image_filter", "True"));
-				combo_filter_nsfw.append("false", C_("imagesource_steamgriddb_image_filter", "False"));
-				combo_filter_nsfw.append("any", C_("imagesource_steamgriddb_image_filter", "Any"));
+				combo_filter_nsfw.append("true", C_("imagesource_steamgriddb_image_filter", "Only"));
+				combo_filter_nsfw.append("false", C_("imagesource_steamgriddb_image_filter", "None"));
+				combo_filter_nsfw.append("any", C_("imagesource_steamgriddb_image_filter", "Doesn't matter"));
 				combo_filter_nsfw.set_active_id(settings.filter_nsfw);
 				combo_filter_nsfw.changed.connect(() => { settings.filter_nsfw = combo_filter_nsfw.get_active_id(); });
 

--- a/src/data/providers/images/SteamGridDB.vala
+++ b/src/data/providers/images/SteamGridDB.vala
@@ -27,7 +27,7 @@ namespace GameHub.Data.Providers.Images
 		private const string BASE_URL     = DOMAIN + "/api/v2";
 		private const string API_KEY_PAGE = DOMAIN + "/profile/preferences";
 
-		private ImagesProvider.ImageSize?[] SIZES = { null, ImageSize(460, 215), ImageSize(920, 430), ImageSize(600, 900), ImageSize(342, 482) };
+		private ImagesProvider.ImageSize?[] SIZES = { ImageSize(460, 215), ImageSize(920, 430), ImageSize(600, 900), ImageSize(342, 482), ImageSize(660, 930), ImageSize(512, 512), ImageSize(1024, 1024) };
 
 		public override string id   { get { return "steamgriddb"; } }
 		public override string name { get { return "SteamGridDB"; } }
@@ -38,6 +38,82 @@ namespace GameHub.Data.Providers.Images
 		{
 			get { return Settings.Providers.Images.SteamGridDB.instance.enabled; }
 			set { Settings.Providers.Images.SteamGridDB.instance.enabled = value; }
+		}
+
+		public enum FilterHumor
+		{
+			TRUE, FALSE, ANY;
+
+			public string value()
+			{
+				switch (this)
+				{
+					case FilterHumor.TRUE:  return "true";
+					case FilterHumor.FALSE: return "false";
+					case FilterHumor.ANY:   return "any";
+				}
+				assert_not_reached();
+			}
+
+			public static FilterHumor from_string(string setting)
+			{
+				switch (setting)
+				{
+					case "true":  return FilterHumor.TRUE;
+					case "false": return FilterHumor.FALSE;
+					case "any":   return FilterHumor.ANY;
+				}
+				assert_not_reached();
+			}
+
+			public string name()
+			{
+				switch(this)
+				{
+					case FilterHumor.TRUE:  return C_("imagesource_steamgriddb_image_filter", "True");
+					case FilterHumor.FALSE: return C_("imagesource_steamgriddb_image_filter", "False");
+					case FilterHumor.ANY:   return C_("imagesource_steamgriddb_image_filter", "Any");
+				}
+				assert_not_reached();
+			}
+		}
+
+		public enum FilterNsfw
+		{
+			TRUE, FALSE, ANY;
+
+			public string value()
+			{
+				switch (this)
+				{
+					case FilterNsfw.TRUE:  return "true";
+					case FilterNsfw.FALSE: return "false";
+					case FilterNsfw.ANY:   return "any";
+				}
+				assert_not_reached();
+			}
+
+			public static FilterNsfw from_string(string setting)
+			{
+				switch (setting)
+				{
+					case "true":  return FilterNsfw.TRUE;
+					case "false": return FilterNsfw.FALSE;
+					case "any":   return FilterNsfw.ANY;
+				}
+				assert_not_reached();
+			}
+
+			public string name()
+			{
+				switch(this)
+				{
+					case FilterNsfw.TRUE:  return C_("imagesource_steamgriddb_image_filter", "True");
+					case FilterNsfw.FALSE: return C_("imagesource_steamgriddb_image_filter", "False");
+					case FilterNsfw.ANY:   return C_("imagesource_steamgriddb_image_filter", "Any");
+				}
+				assert_not_reached();
+			}
 		}
 
 		public override async ArrayList<ImagesProvider.Result> images(Game game)
@@ -61,13 +137,16 @@ namespace GameHub.Data.Providers.Images
 					foreach(var size in SIZES)
 					{
 						var result = new ImagesProvider.Result();
-						result.image_size = size ?? ImageSize(460, 215);
+						result.image_size = size;
 						result.name = "%s: %s (%d × %d)".printf(name, g.name, result.image_size.width, result.image_size.height);
 						result.url = "%s/game/%s".printf(DOMAIN, g.id);
 
-						var dimensions = size != null ? "?dimensions=%dx%d".printf(size.width, size.height) : "";
+						var filter_humor = "?humor=%s".printf(Settings.Providers.Images.SteamGridDB.instance.filter_humor);
+						var filter_nsfw = "&nsfw=%s".printf(Settings.Providers.Images.SteamGridDB.instance.filter_nsfw);
+						var types = "&types=static"; // GameHub can't display apng anyway.
+						var dimensions = "&dimensions=%dx%d".printf(size.width, size.height);
 
-						var endpoint = "/grids/game/%s%s".printf(g.id, dimensions);
+						var endpoint = "/grids/game/%s%s%s%s%s".printf(g.id, filter_humor, filter_nsfw, types, dimensions);
 						//if(game is GameHub.Data.Sources.Steam.SteamGame) endpoint = "/grids/steam/%s%s".printf(game.id, dimensions);
 
 						var root = yield Parser.parse_remote_json_file_async(BASE_URL + endpoint, "GET", Settings.Providers.Images.SteamGridDB.instance.api_key);
@@ -186,6 +265,42 @@ namespace GameHub.Data.Providers.Images
 
 				grid.attach(label, 0, 0);
 				grid.attach(entry_wrapper, 1, 0);
+
+				var label_filter_humor = new Gtk.Label(_("Humoristic images"));
+				label_filter_humor.halign = Gtk.Align.START;
+				label_filter_humor.valign = Gtk.Align.CENTER;
+				label_filter_humor.hexpand = true;
+
+				var combo_filter_humor = new Gtk.ComboBoxText();
+				combo_filter_humor.halign = Gtk.Align.END;
+				combo_filter_humor.valign = Gtk.Align.CENTER;
+				combo_filter_humor.hexpand = false;
+				combo_filter_humor.append(FilterHumor.TRUE.value(), FilterHumor.TRUE.name());
+				combo_filter_humor.append(FilterHumor.FALSE.value(), FilterHumor.FALSE.name());
+				combo_filter_humor.append(FilterHumor.ANY.value(), FilterHumor.ANY.name());
+				combo_filter_humor.set_active_id(FilterHumor.from_string(settings.filter_humor).value());
+				combo_filter_humor.changed.connect(() => { settings.filter_humor = combo_filter_humor.get_active_id(); });
+
+				grid.attach(label_filter_humor, 0, 1);
+				grid.attach(combo_filter_humor, 1, 1);
+
+				var label_filter_nsfw = new Gtk.Label(_("NSFW images"));
+				label_filter_nsfw.halign = Gtk.Align.START;
+				label_filter_nsfw.valign = Gtk.Align.CENTER;
+				label_filter_nsfw.hexpand = true;
+
+				var combo_filter_nsfw = new Gtk.ComboBoxText();
+				combo_filter_nsfw.halign = Gtk.Align.END;
+				combo_filter_nsfw.valign = Gtk.Align.CENTER;
+				combo_filter_nsfw.hexpand = false;
+				combo_filter_nsfw.append(FilterNsfw.TRUE.value(), FilterNsfw.TRUE.name());
+				combo_filter_nsfw.append(FilterNsfw.FALSE.value(), FilterNsfw.FALSE.name());
+				combo_filter_nsfw.append(FilterNsfw.ANY.value(), FilterNsfw.ANY.name());
+				combo_filter_nsfw.set_active_id(FilterNsfw.from_string(settings.filter_nsfw).value());
+				combo_filter_nsfw.changed.connect(() => { settings.filter_nsfw = combo_filter_nsfw.get_active_id(); });
+
+				grid.attach(label_filter_nsfw, 0, 2);
+				grid.attach(combo_filter_nsfw, 1, 2);
 
 				return grid;
 			}

--- a/src/settings/Providers.vala
+++ b/src/settings/Providers.vala
@@ -26,6 +26,8 @@ namespace GameHub.Settings.Providers
 		{
 			public bool enabled { get; set; }
 			public string api_key { get; set; }
+			public string filter_humor { get; set; }
+			public string filter_nsfw { get; set; }
 
 			public SteamGridDB()
 			{


### PR DESCRIPTION
This allows to set the `humor` and `nsfw` for api calls to SteamGridDB.
They have three states:
* Only include filtered images
* Exclude filtered images (default)
* Show all results

Additionally I've completed the size array with new supported sizes.

I'm not entirely sure what the `null` size is about. It only makes another list entry with scrambled sizes in various formats in it. I removed it for now as I can't see where this is beneficial.