### PR TITLE
Implement SteamGridDB filter settings

### DIFF
--- a/data/gamehub.gschema.xml.in
+++ b/data/gamehub.gschema.xml.in
@@ -343,6 +343,14 @@
 				<default>'@PREF_API_KEY_STEAMGRIDDB@'</default>
 				<summary>SteamGridDB API key</summary>
 			</key>
+			<key name="filter-humor" type="s">
+				<default>'false'</default>
+				<summary>SteamGridDB humor filter setting</summary>
+			</key>
+			<key name="filter-nsfw" type="s">
+				<default>'false'</default>
+				<summary>SteamGridDB NSFW filter setting</summary>
+			</key>
 		</schema>
 
 		<schema path="@SCHEMA_PATH@/providers/images/jinx-sgvi/" id="@SCHEMA_ID@.providers.images.jinx-sgvi">

--- a/src/settings/Providers.vala
+++ b/src/settings/Providers.vala
@@ -26,6 +26,8 @@ namespace GameHub.Settings.Providers
 		{
 			public bool enabled { get; set; }
 			public string api_key { get; set; }
+			public string filter_humor { get; set; }
+			public string filter_nsfw { get; set; }
 
 			public SteamGridDB()
 			{


### PR DESCRIPTION
This allows to set the `humor` and `nsfw` for api calls to SteamGridDB.
They have three states:
* Only include filtered images
* Exclude filtered images (default)
* Show all results

Additionally I've completed the size array with new supported sizes.

I'm not entirely sure what the `null` size is about. It only makes another list entry with scrambled sizes in various formats in it.