### PR TITLE
Option to enable dialog resizing

### DIFF
--- a/data/com.github.tkashkin.gamehub.gschema.xml.in
+++ b/data/com.github.tkashkin.gamehub.gschema.xml.in
@@ -128,6 +128,10 @@
 				<default>true</default>
 				<summary>Import tags</summary>
 			</key>
+			<key name="dialogs-resize" type="b">
+				<default>true</default>
+				<summary>Enable dialogs resizing</summary>
+			</key>
 		</schema>
 
 	<!-- Auth -->

--- a/src/settings/UI.vala
+++ b/src/settings/UI.vala
@@ -201,6 +201,7 @@ namespace GameHub.Settings.UI
 		public bool grid_doubleclick { get; set; }
 		public bool merge_games { get; set; }
 		public bool import_tags { get; set; }
+		public bool dialogs_resize { get; set; }
 
 		public Behavior()
 		{

--- a/src/ui/dialogs/GameDetailsDialog.vala
+++ b/src/ui/dialogs/GameDetailsDialog.vala
@@ -30,7 +30,7 @@ namespace GameHub.UI.Dialogs
 
 		public GameDetailsDialog(Game? game)
 		{
-			Object(transient_for: Windows.MainWindow.instance, resizable: false, title: game.name, game: game);
+			Object(transient_for: Windows.MainWindow.instance, resizable: Settings.UI.Behavior.instance.dialogs_resize, title: game.name, game: game);
 		}
 
 		construct

--- a/src/ui/dialogs/GamePropertiesDialog.vala
+++ b/src/ui/dialogs/GamePropertiesDialog.vala
@@ -46,7 +46,7 @@ namespace GameHub.UI.Dialogs
 
 		public GamePropertiesDialog(Game? game)
 		{
-			Object(transient_for: Windows.MainWindow.instance, resizable: false, title: _("%s: Properties").printf(game.name), game: game);
+			Object(transient_for: Windows.MainWindow.instance, resizable: Settings.UI.Behavior.instance.dialogs_resize , title: _("%s: Properties").printf(game.name), game: game);
 		}
 
 		construct

--- a/src/ui/dialogs/SettingsDialog/pages/ui/Behavior.vala
+++ b/src/ui/dialogs/SettingsDialog/pages/ui/Behavior.vala
@@ -48,6 +48,11 @@ namespace GameHub.UI.Dialogs.SettingsDialog.Pages.UI
 			add_separator();
 
 			add_switch(_("Use imported tags"), settings.import_tags, v => { settings.import_tags = v; });
+			            
+			add_separator( );
+            
+			add_switch( _( "Enable resizing of the 'Game properties' dialog and the 'Game details' dialog" ), settings.dialogs_resize, v => { settings.dialogs_resize = v; });
+
 		}
 	}
 }


### PR DESCRIPTION
I added a new option button to "Settings > Interface > Behavior" allowing the user to allow resizing of the "Game Properties" and "Game Details" dialogs windows.

Note:
In some games, there are simply too many objects to display, and the window layout makes them opaque. By simply changing the size, the text, images (etc...) are regrouped and easier to navigate in them.